### PR TITLE
Add numeric ID to RexsValueType and RexsUnitId

### DIFF
--- a/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import info.rexs.db.constants.standard.RexsStandardUnitIds;
+import lombok.Getter;
 
 /**
  * This class represents a REXS unit.
@@ -30,12 +31,15 @@ import info.rexs.db.constants.standard.RexsStandardUnitIds;
  *
  * @author FVA GmbH
  */
+@Getter
 public class RexsUnitId implements RexsStandardUnitIds {
 
 	/** An internal index with all created units (REXS standard and own) for quick access. */
-	private static Map<String, RexsUnitId> allUnitIds = new HashMap<>();
+	private static final Map<String, RexsUnitId> allUnitIds = new HashMap<>();
 
-	/** The actual unit ID as a {@link String}. */
+	/**
+	 * The actual unit ID as a {@link String}.
+     */
 	private final String id;
 
 	protected RexsUnitId(String id) {
@@ -44,15 +48,7 @@ public class RexsUnitId implements RexsStandardUnitIds {
 		this.id = id;
 	}
 
-	/**
-	 * @return
-	 * 				The actual unit ID as a {@link String}.
-	 */
-	public String getId() {
-		return id;
-	}
-
-	/**
+    /**
 	 * TODO Document me!
 	 *
 	 * @param checkUnitIds
@@ -103,7 +99,7 @@ public class RexsUnitId implements RexsStandardUnitIds {
 		if (id == null)
 			return null;
 		if (id.isEmpty())
-			return RexsUnitId.none;
+			return RexsStandardUnitIds.none;
 		RexsStandardUnitIds.init();
 		return allUnitIds.getOrDefault(id, UNKNOWN);
 	}

--- a/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
@@ -41,11 +41,21 @@ public class RexsUnitId implements RexsStandardUnitIds {
 	 * The actual unit ID as a {@link String}.
      */
 	private final String id;
+	private int numericId = 0;
 
-	protected RexsUnitId(String id) {
+	private RexsUnitId(String id) {
 		if (id == null || id.isEmpty())
 			throw new IllegalArgumentException("id cannot be empty");
 		this.id = id;
+	}
+
+	private RexsUnitId(String id, int numericId) {
+		if (id == null || id.isEmpty())
+			throw new IllegalArgumentException("id cannot be empty");
+		if (numericId < 0)
+			throw new IllegalArgumentException("numericId cannot be negative");
+		this.id = id;
+		this.numericId = numericId;
 	}
 
     /**
@@ -86,6 +96,27 @@ public class RexsUnitId implements RexsStandardUnitIds {
 		return unitId;
 	}
 
+	public static RexsUnitId create(String id, int numericId) {
+		// check for zero
+		if (numericId == 0) {
+			return create(id);
+		}
+
+		// create unit ID
+		RexsUnitId unitId = new RexsUnitId(id, numericId);
+
+		// check for uniqueness of numericId
+		for (RexsUnitId unit : allUnitIds.values()) {
+			if (unit.numericId == numericId) {
+				throw new IllegalArgumentException("numericId already exists");
+			}
+		}
+
+		// add unit ID to index
+		allUnitIds.put(id, unitId);
+		return unitId;
+	}
+
 	/**
 	 * Returns the unit ID for a textual ID from the internally stored index of all unit IDs.
 	 *
@@ -102,6 +133,15 @@ public class RexsUnitId implements RexsStandardUnitIds {
 			return RexsStandardUnitIds.none;
 		RexsStandardUnitIds.init();
 		return allUnitIds.getOrDefault(id, UNKNOWN);
+	}
+
+	public static RexsUnitId findById(int numericId) {
+		for (RexsUnitId unit : allUnitIds.values()) {
+			if (unit.numericId == numericId) {
+				return unit;
+			}
+		}
+		return UNKNOWN;
 	}
 
 	/**

--- a/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
@@ -58,14 +58,13 @@ public class RexsUnitId implements RexsStandardUnitIds {
 		this.numericId = numericId;
 	}
 
-    /**
-	 * TODO Document me!
+	/**
+	 * Checks if the unit is one of the specified units.
 	 *
 	 * @param checkUnitIds
-	 * 				TODO Document me!
-	 *
+	 * 				The units to check against.
 	 * @return
-	 * 				TODO Document me!
+	 * 				{@code true} if this unit is one of the specified units, otherwise {@code false}.
 	 */
 	public boolean isOneOf(RexsUnitId ... checkUnitIds)
 	{
@@ -96,6 +95,17 @@ public class RexsUnitId implements RexsStandardUnitIds {
 		return unitId;
 	}
 
+	/**
+	 * Creates a new unit ID with a numeric ID and adds it to the internal index.
+	 *
+	 * @param id
+	 * 				The actual unit ID as a {@link String}.
+	 * @param numericId
+	 * 				The numeric ID associated with the unit.
+	 * @return
+	 * 				The newly created unit ID as {@link RexsUnitId}.
+	 * @throws IllegalArgumentException if the numericId already exists.
+	 */
 	public static RexsUnitId create(String id, int numericId) {
 		// check for zero
 		if (numericId == 0) {

--- a/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
@@ -37,10 +37,10 @@ public class RexsUnitId implements RexsStandardUnitIds {
 	/** An internal index with all created units (REXS standard and own) for quick access. */
 	private static final Map<String, RexsUnitId> allUnitIds = new HashMap<>();
 
-	/**
-	 * The actual unit ID as a {@link String}.
-     */
+	/** The actual unit ID as a {@link String}. */
 	private final String id;
+
+	/** The units unique numeric ID as a {@link int}. */
 	private int numericId = 0;
 
 	private RexsUnitId(String id) {

--- a/api/src/main/java/info/rexs/db/constants/RexsValueType.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsValueType.java
@@ -15,6 +15,10 @@
  ******************************************************************************/
 package info.rexs.db.constants;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * This enum represents a REXS value type.
  * <p>
@@ -22,101 +26,109 @@ package info.rexs.db.constants;
  *
  * @author FVA GmbH
  */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum RexsValueType {
 
-	BOOLEAN("boolean"),
-	BOOLEAN_ARRAY("boolean_array", BOOLEAN),
-	BOOLEAN_MATRIX("boolean_matrix", BOOLEAN),
-	STRING("string"),
-	STRING_ARRAY("string_array", STRING),
-	STRING_MATRIX("string_matrix", STRING),
-	INTEGER("integer"),
-	INTEGER_ARRAY("integer_array", INTEGER),
-	INTEGER_MATRIX("integer_matrix", INTEGER),
-	FLOATING_POINT("floating_point"),
-	FLOATING_POINT_ARRAY("floating_point_array", FLOATING_POINT),
-	FLOATING_POINT_MATRIX("floating_point_matrix", FLOATING_POINT),
-	ENUM("enum"),
-	ENUM_ARRAY("enum_array", ENUM),
-	ARRAY_OF_INTEGER_ARRAYS("array_of_integer_arrays", INTEGER),
-	REFERENCE_COMPONENT("reference_component"),
-	FILE_REFERENCE("file_reference"),
-	DATE_TIME("date_time");
+    BOOLEAN(2, "boolean"),
+    BOOLEAN_ARRAY(7, "boolean_array", BOOLEAN),
+    BOOLEAN_MATRIX(16, "boolean_matrix", BOOLEAN),
+    STRING(5, "string"),
+    STRING_ARRAY(14, "string_array", STRING),
+    STRING_MATRIX(17, "string_matrix", STRING),
+    INTEGER(3, "integer"),
+    INTEGER_ARRAY(11, "integer_array", INTEGER),
+    INTEGER_MATRIX(15, "integer_matrix", INTEGER),
+    FLOATING_POINT(1, "floating_point"),
+    FLOATING_POINT_ARRAY(8, "floating_point_array", FLOATING_POINT),
+    FLOATING_POINT_MATRIX(10, "floating_point_matrix", FLOATING_POINT),
+    ENUM(4, "enum"),
+    ENUM_ARRAY(12, "enum_array", ENUM),
+    ARRAY_OF_INTEGER_ARRAYS(13, "array_of_integer_arrays", INTEGER),
+    REFERENCE_COMPONENT(9, "reference_component"),
+    FILE_REFERENCE(6, "file_reference"),
+    DATE_TIME(19, "date_time");
 
-	/** The actual key of the value type as a {@link String}. */
-	private final String key;
+    /**
+     * The numeric ID of this value type.
+     */
+    private final int numericId;
+    /**
+     * The actual key of the value type.
+     */
+    private final String key;
+    /**
+     * The base type associated with the value type.
+     */
+    private final RexsValueType basicType;
 
-	/** The base type associated with the data type. */
-	private final RexsValueType basicType;
 
-	private RexsValueType(String key, RexsValueType basicType) {
-		this.key = key;
-		this.basicType = basicType;
-	}
+    /**
+     * Constructs a new RexsValueType with the specified numeric ID and key.
+     *
+     * @param id  The numeric ID of the RexsValueType.
+     * @param key The actual key of the RexsValueType as a String.
+     */
+    RexsValueType(int id, String key) {
+        this(id, key, null);
+    }
 
-	private RexsValueType(String key) {
-		this(key, null);
-	}
 
-	/**
-	 * @return
-	 * 				The actual key of the value type as a {@link String}.
-	 */
-	public String getKey() {
-		return key;
-	}
+    /**
+     * Returns the value type for a textual key of all value types.
+     *
+     * @param key The actual key of the value type to be found as a {@link String}
+     * @return The found value type as {@link RexsValueType}, or {@code null} if the key could not be found.
+     */
+    public static RexsValueType findByKey(String key) {
+        if (key == null)
+            return null;
 
-	/**
-	 * @return
-	 * 				The base type associated with the data type.
-	 */
-	public RexsValueType getBasicType() {
-		if (basicType == null)
-			return this;
-		return basicType;
-	}
+        for (RexsValueType valueType : values()) {
+            if (key.equals(valueType.getKey()))
+                return valueType;
+        }
 
-	/**
-	 * TODO Document me!
-	 *
-	 * @param checkValueTypes
-	 * 				TODO Document me!
-	 *
-	 * @return
-	 * 				TODO Document me!
-	 */
-	public boolean isOneOf(RexsValueType ... checkValueTypes)
-	{
-		if (checkValueTypes == null)
-			return false;
+        return null;
+    }
 
-		for (RexsValueType checkValueType : checkValueTypes)
-		{
-			if (this == checkValueType)
-				return true;
-		}
+    /**
+     * Returns the value type for a numeric ID of all value types.
+     *
+     * @param numericId The numeric ID of the value type to be found.
+     * @return The found value type as {@link RexsValueType}, or {@code null} if the ID could not be found.
+     */
+    public static RexsValueType findByNumericId(int numericId) {
+        for (RexsValueType valueType : values()) {
+            if (valueType.getNumericId() == numericId)
+                return valueType;
+        }
+        return null;
+    }
 
-		return false;
-	}
+    /**
+     * @return The base type associated with the data type.
+     */
+    public RexsValueType getBasicType() {
+        if (basicType == null)
+            return this;
+        return basicType;
+    }
 
-	/**
-	 * Returns the value type for a textual key of all value types.
-	 *
-	 * @param key
-	 * 				The actual key of the value type to be found as a {@link String}
-	 *
-	 * @return
-	 * 				The found value type as {@link RexsValueType}, or {@code null} if the key could not be found.
-	 */
-	public static RexsValueType findByKey(String key) {
-		if (key == null)
-			return null;
+    /**
+     * Determines whether this RexsValueType is one of the specified RexsValueTypes.
+     *
+     * @param checkValueTypes The RexsValueTypes to check against.
+     * @return true if this RexsValueType is one of the specified types, false otherwise.
+     */
+    public boolean isOneOf(RexsValueType... checkValueTypes) {
+        if (checkValueTypes == null)
+            return false;
 
-		for (RexsValueType valueType : values()) {
-			if (key.equals(valueType.getKey()))
-				return valueType;
-		}
-
-		return null;
-	}
+        for (RexsValueType checkValueType : checkValueTypes) {
+            if (this == checkValueType)
+                return true;
+        }
+        return false;
+    }
 }

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardUnitIds.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardUnitIds.java
@@ -37,184 +37,187 @@ public interface RexsStandardUnitIds {
 	 * <p>From REXS version 1.4 use {@link #deg} instead.
 	 */
 	@Deprecated
-	public static final RexsUnitId degree = RexsUnitId.create("\u00B0");
+	public static final RexsUnitId degree = RexsUnitId.create("\u00B0", 3);
 
 	/** dB */
-	public static final RexsUnitId db = RexsUnitId.create("dB");
+	public static final RexsUnitId db = RexsUnitId.create("dB", 51);
 
 	/** deg */
-	public static final RexsUnitId deg = RexsUnitId.create("deg");
+	public static final RexsUnitId deg = RexsUnitId.create("deg", 58);
 
 	/** C */
-	public static final RexsUnitId degree_celsius = RexsUnitId.create("C");
+	public static final RexsUnitId degree_celsius = RexsUnitId.create("C", 1);
 
 	/** HB */
-	public static final RexsUnitId hb = RexsUnitId.create("HB");
+	public static final RexsUnitId hb = RexsUnitId.create("HB", 28);
 
 	/** K (m / s)^0.75 mm^1.75 / W */
-	public static final RexsUnitId heat_transfer_coefficient_vdi2736 = RexsUnitId.create("K (m / s)^0.75 mm^1.75 / W");
+	public static final RexsUnitId heat_transfer_coefficient_vdi2736 = RexsUnitId.create("K (m / s)^0.75 mm^1.75 / W", 40);
 
 	/** Hz */
-	public static final RexsUnitId hertz = RexsUnitId.create("Hz");
+	public static final RexsUnitId hertz = RexsUnitId.create("Hz", 32);
 
 	/** h */
-	public static final RexsUnitId hour = RexsUnitId.create("h");
+	public static final RexsUnitId hour = RexsUnitId.create("h", 17);
 
 	/** HRC */
-	public static final RexsUnitId hrc = RexsUnitId.create("HRC");
+	public static final RexsUnitId hrc = RexsUnitId.create("HRC", 27);
 
 	/** HV */
-	public static final RexsUnitId hv = RexsUnitId.create("HV");
+	public static final RexsUnitId hv = RexsUnitId.create("HV", 18);
 
 	/** J / (kg K) */
-	public static final RexsUnitId j_per_kg_k = RexsUnitId.create("J / (kg K)");
+	public static final RexsUnitId j_per_kg_k = RexsUnitId.create("J / (kg K)", 23);
 
 	/** K */
-	public static final RexsUnitId kelvin = RexsUnitId.create("K");
+	public static final RexsUnitId kelvin = RexsUnitId.create("K", 6);
 
 	/** K m^2 / W */
-	public static final RexsUnitId kelvin_m2_per_watt = RexsUnitId.create("K m^2 / W");
+	public static final RexsUnitId kelvin_m2_per_watt = RexsUnitId.create("K m^2 / W", 36);
 
 	/** K / mus */
-	public static final RexsUnitId kelvin_per_mus = RexsUnitId.create("K / mus");
+	public static final RexsUnitId kelvin_per_mus = RexsUnitId.create("K / mus", 50);
 
 	/** kg */
-	public static final RexsUnitId kg = RexsUnitId.create("kg");
+	public static final RexsUnitId kg = RexsUnitId.create("kg", 56);
 
 	/** kg m^2 */
-	public static final RexsUnitId kg_m2 = RexsUnitId.create("kg m^2");
+	public static final RexsUnitId kg_m2 = RexsUnitId.create("kg m^2", 57);
 
 	/** kg / dm^3 */
-	public static final RexsUnitId kg_per_dm3 = RexsUnitId.create("kg / dm^3");
+	public static final RexsUnitId kg_per_dm3 = RexsUnitId.create("kg / dm^3", 21);
 
 	/** kN */
-	public static final RexsUnitId kilo_newton = RexsUnitId.create("kN");
+	public static final RexsUnitId kilo_newton = RexsUnitId.create("kN", 5);
 
 	/** kW */
-	public static final RexsUnitId kilo_watt = RexsUnitId.create("kW");
+	public static final RexsUnitId kilo_watt = RexsUnitId.create("kW", 30);
 
 	/** l / min */
-	public static final RexsUnitId litre_per_minute = RexsUnitId.create("l / min");
+	public static final RexsUnitId litre_per_minute = RexsUnitId.create("l / min", 16);
 
 	/** m^2 */
-	public static final RexsUnitId m2 = RexsUnitId.create("m^2");
+	public static final RexsUnitId m2 = RexsUnitId.create("m^2", 35);
 
 	/** m^3 / s */
-	public static final RexsUnitId m3_per_second = RexsUnitId.create("m^3 / s");
+	public static final RexsUnitId m3_per_second = RexsUnitId.create("m^3 / s", 53);
 
 	/** m / s^2 */
-	public static final RexsUnitId m_per_s2 = RexsUnitId.create("m / s^2");
+	public static final RexsUnitId m_per_s2 = RexsUnitId.create("m / s^2", 33);
 
 	/** m / s */
-	public static final RexsUnitId m_per_second = RexsUnitId.create("m / s");
+	public static final RexsUnitId m_per_second = RexsUnitId.create("m / s", 34);
 
 	/** MPa */
-	public static final RexsUnitId mega_pascal = RexsUnitId.create("MPa");
+	public static final RexsUnitId mega_pascal = RexsUnitId.create("MPa", 14);
 
 	/** mg */
-	public static final RexsUnitId mg = RexsUnitId.create("mg");
+	public static final RexsUnitId mg = RexsUnitId.create("mg", 41);
 
 	/** mm */
-	public static final RexsUnitId mm = RexsUnitId.create("mm");
+	public static final RexsUnitId mm = RexsUnitId.create("mm", 2);
 
 	/** mm^2 */
-	public static final RexsUnitId mm2 = RexsUnitId.create("mm^2");
+	public static final RexsUnitId mm2 = RexsUnitId.create("mm^2", 54);
 
 	/** mm^2 / N */
-	public static final RexsUnitId mm2_per_newton = RexsUnitId.create("mm^2 / N");
+	public static final RexsUnitId mm2_per_newton = RexsUnitId.create("mm^2 / N", 44);
 
 	/** mm^2 / s */
-	public static final RexsUnitId mm2_per_s = RexsUnitId.create("mm^2 / s");
+	public static final RexsUnitId mm2_per_s = RexsUnitId.create("mm^2 / s", 24);
 
 	/** mm / h */
-	public static final RexsUnitId mm_per_h = RexsUnitId.create("mm / h");
+	public static final RexsUnitId mm_per_h = RexsUnitId.create("mm / h", 43);
 
 	/** mPa s */
-	public static final RexsUnitId mpa_s = RexsUnitId.create("mPa s");
+	public static final RexsUnitId mpa_s = RexsUnitId.create("mPa s", 46);
 
 	/** mum */
-	public static final RexsUnitId mum = RexsUnitId.create("mum");
+	public static final RexsUnitId mum = RexsUnitId.create("mum", 11);
 
 	/** mus */
-	public static final RexsUnitId mus = RexsUnitId.create("mus");
+	public static final RexsUnitId mus = RexsUnitId.create("mus", 49);
 
 	/** N */
-	public static final RexsUnitId newton = RexsUnitId.create("N");
+	public static final RexsUnitId newton = RexsUnitId.create("N", 10);
 
 	/** N m */
-	public static final RexsUnitId newton_m = RexsUnitId.create("N m");
+	public static final RexsUnitId newton_m = RexsUnitId.create("N m", 12);
 
 	/** N mm / rad */
-	public static final RexsUnitId newton_mm_per_rad = RexsUnitId.create("N mm / rad");
+	public static final RexsUnitId newton_mm_per_rad = RexsUnitId.create("N mm / rad", 8);
 
 	/** N / m */
-	public static final RexsUnitId newton_per_m = RexsUnitId.create("N / m");
+	public static final RexsUnitId newton_per_m = RexsUnitId.create("N / m", 9);
 
 	/** N / mm */
-	public static final RexsUnitId newton_per_mm = RexsUnitId.create("N / mm");
+	public static final RexsUnitId newton_per_mm = RexsUnitId.create("N / mm", 45);
 
 	/** N / mm^2 */
-	public static final RexsUnitId newton_per_mm2 = RexsUnitId.create("N / mm^2");
+	public static final RexsUnitId newton_per_mm2 = RexsUnitId.create("N / mm^2", 19);
 
 	/** (N / mm^2)^0.5 */
-	public static final RexsUnitId newton_per_mm2_then_squareroot = RexsUnitId.create("(N / mm^2)^0.5");
+	public static final RexsUnitId newton_per_mm2_then_squareroot = RexsUnitId.create("(N / mm^2)^0.5", 38);
 
 	/** N / (mm mum) */
-	public static final RexsUnitId newton_per_mm_mum = RexsUnitId.create("N / (mm mum)");
+	public static final RexsUnitId newton_per_mm_mum = RexsUnitId.create("N / (mm mum)", 37);
 
 	/** N / (mm s^0.5 K) */
-	public static final RexsUnitId newton_per_mm_s_then_squareroot_k = RexsUnitId.create("N / (mm s^0.5 K)");
+	public static final RexsUnitId newton_per_mm_s_then_squareroot_k = RexsUnitId.create("N / (mm s^0.5 K)", 47);
 
 	/** N / rad */
-	public static final RexsUnitId newton_per_radian = RexsUnitId.create("N / rad");
+	public static final RexsUnitId newton_per_radian = RexsUnitId.create("N / rad", 31);
 
 	/** none */
-	public static final RexsUnitId none = RexsUnitId.create("none");
+	public static final RexsUnitId none = RexsUnitId.create("none", 4);
 
 	/** Pa */
-	public static final RexsUnitId pascal = RexsUnitId.create("Pa");
+	public static final RexsUnitId pascal = RexsUnitId.create("Pa", 52);
 
 	/** 1 / mm */
-	public static final RexsUnitId per_mm = RexsUnitId.create("1 / mm");
+	public static final RexsUnitId per_mm = RexsUnitId.create("1 / mm", 55);
 
 	/** % */
-	public static final RexsUnitId percent = RexsUnitId.create("%");
+	public static final RexsUnitId percent = RexsUnitId.create("%", 7);
 
 	/** rad */
-	public static final RexsUnitId radian = RexsUnitId.create("rad");
+	public static final RexsUnitId radian = RexsUnitId.create("rad", 13);
 
 	/** rad / s */
-	public static final RexsUnitId radian_per_s = RexsUnitId.create("rad / s");
+	public static final RexsUnitId radian_per_s = RexsUnitId.create("rad / s", 48);
 
 	/** 1 / min */
-	public static final RexsUnitId rotation_per_min = RexsUnitId.create("1 / min");
+	public static final RexsUnitId rotation_per_min = RexsUnitId.create("1 / min", 25);
 
 	/** 1 / s */
-	public static final RexsUnitId rotation_per_second = RexsUnitId.create("1 / s");
+	public static final RexsUnitId rotation_per_second = RexsUnitId.create("1 / s", 42);
 
 	/** s */
-	public static final RexsUnitId second = RexsUnitId.create("s");
+	public static final RexsUnitId second = RexsUnitId.create("s", 26);
 
 	/** 1e-6 / C */
-	public static final RexsUnitId thermal_expansion_coefficient = RexsUnitId.create("1e-6 / C");
+	public static final RexsUnitId thermal_expansion_coefficient = RexsUnitId.create("1e-6 / C", 20);
 
 	/** MRev */
-	public static final RexsUnitId unit_59 = RexsUnitId.create("MRev");
+	public static final RexsUnitId unit_59 = RexsUnitId.create("MRev", 59);
 
 	/** W / (m^2 K) */
-	public static final RexsUnitId unit_60 = RexsUnitId.create("W / (m^2 K)");
+	public static final RexsUnitId unit_60 = RexsUnitId.create("W / (m^2 K)", 60);
+
+	/** kg / mm */
+	public static final RexsUnitId unit_61 = RexsUnitId.create("kg / mm", 61);
 
 	/** W */
-	public static final RexsUnitId watt = RexsUnitId.create("W");
+	public static final RexsUnitId watt = RexsUnitId.create("W", 29);
 
 	/** W / (m K) */
-	public static final RexsUnitId watt_per_m_k = RexsUnitId.create("W / (m K)");
+	public static final RexsUnitId watt_per_m_k = RexsUnitId.create("W / (m K)", 22);
 
 	/** W / mm */
-	public static final RexsUnitId watt_per_mm = RexsUnitId.create("W / mm");
+	public static final RexsUnitId watt_per_mm = RexsUnitId.create("W / mm", 15);
 
 	/** 1e-6 mm^3 / (N m) */
-	public static final RexsUnitId wear_coefficient_vdi2736 = RexsUnitId.create("1e-6 mm^3 / (N m)");
+	public static final RexsUnitId wear_coefficient_vdi2736 = RexsUnitId.create("1e-6 mm^3 / (N m)", 39);
 
 	/** Constant for an unknown unit. */
 	public static final RexsUnitId UNKNOWN = RexsUnitId.create("unknown");

--- a/api/src/test/java/info/rexs/db/constants/RexsValueTypeTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsValueTypeTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class RexsValueTypeTest {
 
 	@Test
-	public void getKey_notNullAndNotEmpty() throws Exception {
+	public void getKey_notNullAndNotEmpty() {
 		Stream.of(RexsValueType.values()).forEach(valueType -> {
 			assertThat(valueType.getKey()).isNotNull();
 			assertThat(valueType.getKey()).isNotEmpty();
@@ -34,7 +34,7 @@ public class RexsValueTypeTest {
 	}
 
 	@Test
-	public void getKey_returnsUniqueKey() throws Exception {
+	public void getKey_returnsUniqueKey() {
 		Set<String> usedKeys = new HashSet<>();
 		Stream.of(RexsValueType.values()).forEach(valueType -> {
 			assertThat(usedKeys).doesNotContain(valueType.getKey());
@@ -43,7 +43,21 @@ public class RexsValueTypeTest {
 	}
 
 	@Test
-	public void getBasicType_assignmentsCorrect() throws Exception {
+	public void getNumericId_notZero() {
+		Stream.of(RexsValueType.values()).forEach(valueType -> assertThat(valueType.getNumericId()).isNotZero());
+	}
+
+	@Test
+	public void getNumericId_returnsUniqueValues() {
+		Set<Integer> usedIds = new HashSet<>();
+		Stream.of(RexsValueType.values()).forEach(valueType -> {
+			assertThat(usedIds).doesNotContain(valueType.getNumericId());
+			usedIds.add(valueType.getNumericId());
+		});
+	}
+
+	@Test
+	public void getBasicType_assignmentsCorrect() {
 		assertThat(RexsValueType.BOOLEAN.getBasicType()).isEqualTo(RexsValueType.BOOLEAN);
 		assertThat(RexsValueType.BOOLEAN_ARRAY.getBasicType()).isEqualTo(RexsValueType.BOOLEAN);
 		assertThat(RexsValueType.BOOLEAN_MATRIX.getBasicType()).isEqualTo(RexsValueType.BOOLEAN);
@@ -79,9 +93,48 @@ public class RexsValueTypeTest {
 	}
 
 	@Test
-	public void findByKey_returnsCorrectValueType() throws Exception {
+	public void findByKey_returnsCorrectValueType() {
 		RexsValueType valueType = RexsValueType.findByKey(RexsValueType.FLOATING_POINT_ARRAY.getKey());
 		assertThat(valueType).isNotNull();
 		assertThat(valueType).isEqualTo(RexsValueType.FLOATING_POINT_ARRAY);
+	}
+
+	@Test
+	public void findByNumericId_givenNullReturnsNull() {
+		assertThat(RexsValueType.findByNumericId(0)).isNull();
+	}
+
+	@Test
+	public void findByNumericId_givenUnknownIdReturnsNull() {
+		assertThat(RexsValueType.findByNumericId(-1)).isNull();
+	}
+
+	@Test
+	public void findByNumericId_returnsCorrectValueType() {
+		RexsValueType valueType = RexsValueType.findByNumericId(RexsValueType.FLOATING_POINT_ARRAY.getNumericId());
+		assertThat(valueType).isNotNull();
+		assertThat(valueType).isEqualTo(RexsValueType.FLOATING_POINT_ARRAY);
+	}
+
+	@Test
+	public void isOneOf_returnsTrueForMatchingTypes() {
+		assertThat(RexsValueType.INTEGER.isOneOf(RexsValueType.INTEGER, RexsValueType.INTEGER_ARRAY)).isTrue();
+		assertThat(RexsValueType.INTEGER_ARRAY.isOneOf(RexsValueType.INTEGER, RexsValueType.INTEGER_ARRAY)).isTrue();
+	}
+
+	@Test
+	public void isOneOf_returnsFalseForNonMatchingTypes() {
+		assertThat(RexsValueType.INTEGER.isOneOf(RexsValueType.FLOATING_POINT, RexsValueType.BOOLEAN)).isFalse();
+		assertThat(RexsValueType.FLOATING_POINT.isOneOf(RexsValueType.BOOLEAN_ARRAY, RexsValueType.DATE_TIME)).isFalse();
+	}
+
+	@Test
+	public void isOneOf_returnsFalseForNullArgument() {
+		assertThat(RexsValueType.STRING.isOneOf((RexsValueType[]) null)).isFalse();
+	}
+
+	@Test
+	public void isOneOf_returnsFalseForEmptyArgument() {
+		assertThat(RexsValueType.STRING.isOneOf()).isFalse();
 	}
 }


### PR DESCRIPTION
satisfies steps 1, 2 and 4 given in #117 

The implementation will not break existing workflows. Working with only-String units is still possible.

@karstenroethig 