### PR TITLE
Add "DEV" as a constant version

### DIFF
--- a/api/src/main/java/info/rexs/db/constants/RexsVersion.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsVersion.java
@@ -15,13 +15,11 @@
  ******************************************************************************/
 package info.rexs.db.constants;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import info.rexs.db.constants.standard.RexsStandardVersions;
+import lombok.Getter;
 
 /**
  * This class represents a REXS version.
@@ -36,12 +34,19 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 
 
 	/** An internal index with all created versions (REXS standard and own) for quick access. */
-	private static Set<RexsVersion> allVerions = new HashSet<>();
+	private static final Set<RexsVersion> allVerions = new HashSet<>();
 
-	/** The version name. */
-	private final String name;
+	/**
+     * The version name.
+     */
+	@Getter
+    private final String name;
 
-	private final int order;
+    /**
+     * The version order.
+     */
+    @Getter
+    private final int order;
 
 	/** Alternative version names that can also be assigned to an official version (e.g. a beta version name). */
 	private final Set<String> alternativeNames;
@@ -62,31 +67,12 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 		return V1_6;
 	}
 
-	/**
-	 * @return
-	 * 				The version name as a {@link String}.
-	 */
-	public String getName() {
-		return name;
-	}
-
-	/**
-	 * @return
-	 * 				The version order as a {@code int}.
-	 */
-	public int getOrder() {
-		return order;
-	}
-
-	/**
-	 * TODO Document me!
-	 *
-	 * @param checkVersions
-	 * 				TODO Document me!
-	 *
-	 * @return
-	 * 				TODO Document me!
-	 */
+    /**
+     * Checks if this version is one of the specified versions.
+     *
+     * @param checkVersions An array of {@link RexsVersion} to check against.
+     * @return {@code true} if this version is one of the specified versions; {@code false} otherwise.
+     */
 	public boolean isOneOf(RexsVersion ... checkVersions)
 	{
 		if (checkVersions == null)
@@ -170,16 +156,13 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsVersion)) {
+		if (!(o instanceof RexsVersion other)) {
 			return false;
 		}
-		RexsVersion other = (RexsVersion)o;
-		if (!other.canEqual(this)) {
+        if (!other.canEqual(this)) {
 			return false;
 		}
-		Object this_name = getName();
-		Object other_name = other.getName();
-		return this_name == null ? other_name == null : this_name.equals(other_name);
+        return Objects.equals(getName(), other.getName());
 	}
 
 	protected boolean canEqual(Object other) {
@@ -189,8 +172,7 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 	@Override
 	public int hashCode() {
 		int result = 1;
-		Object _name = getName();
-		result = result * 59 + (_name == null ? 43 : _name.hashCode());
+		result = result * 59 + (name == null ? 43 : name.hashCode());
 		return result;
 	}
 

--- a/api/src/main/java/info/rexs/db/constants/RexsVersion.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsVersion.java
@@ -15,11 +15,14 @@
  ******************************************************************************/
 package info.rexs.db.constants;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import info.rexs.db.constants.standard.RexsStandardVersions;
-import lombok.Getter;
 
 /**
  * This class represents a REXS version.
@@ -36,17 +39,11 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 	/** An internal index with all created versions (REXS standard and own) for quick access. */
 	private static final Set<RexsVersion> allVerions = new HashSet<>();
 
-	/**
-     * The version name.
-     */
-	@Getter
-    private final String name;
+	/** The version name. */
+	private final String name;
 
-    /**
-     * The version order.
-     */
-    @Getter
-    private final int order;
+	/** The version order. */
+	private final int order;
 
 	/** Alternative version names that can also be assigned to an official version (e.g. a beta version name). */
 	private final Set<String> alternativeNames;
@@ -67,19 +64,33 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 		return V1_6;
 	}
 
-    /**
-     * Checks if this version is one of the specified versions.
-     *
-     * @param checkVersions An array of {@link RexsVersion} to check against.
-     * @return {@code true} if this version is one of the specified versions; {@code false} otherwise.
-     */
-	public boolean isOneOf(RexsVersion ... checkVersions)
-	{
+	/**
+	 * @return
+	 * 				The version name as a {@link String}.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * @return
+	 * 				The version order as a {@code int}.
+	 */
+	public int getOrder() {
+		return order;
+	}
+
+	/**
+	 * Checks if this version is one of the specified versions.
+	 *
+	 * @param checkVersions An array of {@link RexsVersion} to check against.
+	 * @return {@code true} if this version is one of the specified versions; {@code false} otherwise.
+	 */
+	public boolean isOneOf(RexsVersion ... checkVersions) {
 		if (checkVersions == null)
 			return false;
 
-		for (RexsVersion checkVersion : checkVersions)
-		{
+		for (RexsVersion checkVersion : checkVersions) {
 			if (this.equals(checkVersion))
 				return true;
 		}
@@ -159,10 +170,10 @@ public class RexsVersion implements RexsStandardVersions, Comparable<RexsVersion
 		if (!(o instanceof RexsVersion other)) {
 			return false;
 		}
-        if (!other.canEqual(this)) {
+		if (!other.canEqual(this)) {
 			return false;
 		}
-        return Objects.equals(getName(), other.getName());
+		return Objects.equals(getName(), other.getName());
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
@@ -18,35 +18,52 @@ package info.rexs.db.constants.standard;
 import info.rexs.db.constants.RexsVersion;
 
 /**
- * TODO Document me!
+ * Standard REXS versions.
  *
- * @author FVA GmbH
+ * @see RexsVersion
+ * @see <a href="https://database.rexs.info/rexs/version/list">REXS Database</a>
  */
 public interface RexsStandardVersions {
+    /**
+     * REXS version 1.0.
+     */
+    RexsVersion V1_0 = RexsVersion.create("1.0", 1000, "0.90", "0.10", "1.00");
 
-	/** 1.0 */
-	RexsVersion V1_0 = RexsVersion.create("1.0", 1000, "0.90", "0.10", "1.00");
+    /**
+     * REXS version 1.1.
+     */
+    RexsVersion V1_1 = RexsVersion.create("1.1", 1100, "1.10", "1.1-Beta");
 
-	/** 1.1 */
-	RexsVersion V1_1 = RexsVersion.create("1.1", 1100, "1.10", "1.1-Beta");
+    /**
+     * REXS version 1.2.
+     */
+    RexsVersion V1_2 = RexsVersion.create("1.2", 1200);
 
-	/** 1.2 */
-	RexsVersion V1_2 = RexsVersion.create("1.2", 1200);
+    /**
+     * REXS version 1.3.
+     */
+    RexsVersion V1_3 = RexsVersion.create("1.3", 1300);
 
-	/** 1.3 */
-	RexsVersion V1_3 = RexsVersion.create("1.3", 1300);
+    /**
+     * REXS version 1.4.
+     */
+    RexsVersion V1_4 = RexsVersion.create("1.4", 1400);
 
-	/** 1.4 */
-	RexsVersion V1_4 = RexsVersion.create("1.4", 1400);
+    /**
+     * REXS version 1.5.
+     */
+    RexsVersion V1_5 = RexsVersion.create("1.5", 1500);
 
-	/** 1.5 */
-	RexsVersion V1_5 = RexsVersion.create("1.5", 1500);
+    /**
+     * REXS version 1.6.
+     */
+    RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
 
-	/** 1.6 */
-	RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
+    /**
+     * Constant for an unknown version.
+     */
+    RexsVersion UNKNOWN = RexsVersion.create("unknown", -1);
 
-	/** Constant for an unknown version. */
-	RexsVersion UNKNOWN = RexsVersion.create("unknown", -1);
-
-	public static void init() {}
+    static void init() {
+    }
 }

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
@@ -24,49 +24,33 @@ import info.rexs.db.constants.RexsVersion;
  * @see <a href="https://database.rexs.info/rexs/version/list">REXS Database</a>
  */
 public interface RexsStandardVersions {
-    /**
-     * REXS version 1.0.
-     */
-    RexsVersion V1_0 = RexsVersion.create("1.0", 1000, "0.90", "0.10", "1.00");
 
-    /**
-     * REXS version 1.1.
-     */
-    RexsVersion V1_1 = RexsVersion.create("1.1", 1100, "1.10", "1.1-Beta");
+	/** REXS version 1.0. */
+	RexsVersion V1_0 = RexsVersion.create("1.0", 1000, "0.90", "0.10", "1.00");
 
-    /**
-     * REXS version 1.2.
-     */
-    RexsVersion V1_2 = RexsVersion.create("1.2", 1200);
+	/** REXS version 1.1. */
+	RexsVersion V1_1 = RexsVersion.create("1.1", 1100, "1.10", "1.1-Beta");
 
-    /**
-     * REXS version 1.3.
-     */
-    RexsVersion V1_3 = RexsVersion.create("1.3", 1300);
+	/** REXS version 1.2. */
+	RexsVersion V1_2 = RexsVersion.create("1.2", 1200);
 
-    /**
-     * REXS version 1.4.
-     */
-    RexsVersion V1_4 = RexsVersion.create("1.4", 1400);
+	/** REXS version 1.3. */
+	RexsVersion V1_3 = RexsVersion.create("1.3", 1300);
 
-    /**
-     * REXS version 1.5.
-     */
-    RexsVersion V1_5 = RexsVersion.create("1.5", 1500);
+	/** REXS version 1.4. */
+	RexsVersion V1_4 = RexsVersion.create("1.4", 1400);
 
-    /**
-     * REXS version 1.6.
-     */
-    RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
-    /**
-     * Constant for the current development version.
-     */
-    RexsVersion DEV = RexsVersion.create("DEV", 9999);
-    /**
-     * Constant for an unknown version.
-     */
-    RexsVersion UNKNOWN = RexsVersion.create("unknown", -1);
+	/** REXS version 1.5. */
+	RexsVersion V1_5 = RexsVersion.create("1.5", 1500);
 
-    static void init() {
-    }
+	/** REXS version 1.6. */
+	RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
+
+	/** Constant for the current development version. */
+	RexsVersion DEV = RexsVersion.create("DEV", 9999);
+
+	/** Constant for an unknown version. */
+	RexsVersion UNKNOWN = RexsVersion.create("unknown", -1);
+
+	static void init() {}
 }

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
@@ -58,7 +58,10 @@ public interface RexsStandardVersions {
      * REXS version 1.6.
      */
     RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
-
+    /**
+     * Constant for the current development version.
+     */
+    RexsVersion DEV = RexsVersion.create("DEV", 9999);
     /**
      * Constant for an unknown version.
      */

--- a/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
@@ -15,12 +15,13 @@
  ******************************************************************************/
 package info.rexs.db.constants;
 
-import static info.rexs.db.constants.standard.RexsStandardVersions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.Test;
+
+import info.rexs.db.constants.standard.RexsStandardVersions;
 
 public class RexsVersionTest {
 
@@ -57,19 +58,19 @@ public class RexsVersionTest {
 
 	@Test
 	public void findByName_givenNullReturnsUnknown() {
-		assertThat(RexsVersion.findByName(null)).isEqualTo(UNKNOWN);
+		assertThat(RexsVersion.findByName(null)).isEqualTo(RexsStandardVersions.UNKNOWN);
 	}
 
 	@Test
 	public void findByName_givenUnknownNameReturnsUnknown() {
-		assertThat(RexsVersion.findByName("foo.bar")).isEqualTo(UNKNOWN);
+		assertThat(RexsVersion.findByName("foo.bar")).isEqualTo(RexsStandardVersions.UNKNOWN);
 	}
 
 	@Test
 	public void findByName_returnsRexsStandardVersion() {
-		RexsVersion version = RexsVersion.findByName(V1_0.getName());
+		RexsVersion version = RexsVersion.findByName(RexsStandardVersions.V1_0.getName());
 		assertThat(version).isNotNull();
-		assertThat(version.getName()).isEqualTo(V1_0.getName());
+		assertThat(version.getName()).isEqualTo(RexsStandardVersions.V1_0.getName());
 	}
 
 	@Test
@@ -99,41 +100,40 @@ public class RexsVersionTest {
 
 	@Test
 	public void isLessOrEqual_whenVersionIsLessOrEqual_returnsTrue() {
-
-        assertThat(V1_0.isLessOrEqual(V1_1)).isTrue();
-		assertThat(V1_1.isLessOrEqual(V1_1)).isTrue();
-		assertThat(V1_2.isLessOrEqual(V1_1)).isFalse();
+		assertThat(RexsStandardVersions.V1_0.isLessOrEqual(RexsStandardVersions.V1_1)).isTrue();
+		assertThat(RexsStandardVersions.V1_1.isLessOrEqual(RexsStandardVersions.V1_1)).isTrue();
+		assertThat(RexsStandardVersions.V1_2.isLessOrEqual(RexsStandardVersions.V1_1)).isFalse();
 	}
 
 	@Test
 	public void isEqual_whenVersionIsEqual_returnsTrue() {
 		RexsVersion V1_1_copy = RexsVersion.create("1.1", 1100);
 
-		assertThat(V1_1.isEqual(V1_1_copy)).isTrue();
-		assertThat(V1_1.isEqual(V1_1)).isTrue();
+		assertThat(RexsStandardVersions.V1_1.isEqual(V1_1_copy)).isTrue();
+		assertThat(RexsStandardVersions.V1_1.isEqual(RexsStandardVersions.V1_1)).isTrue();
 	}
 
 	@Test
 	public void isGreater_whenVersionIsGreater_returnsTrue() {
-		assertThat(V1_2.isGreater(V1_0)).isTrue();
-		assertThat(V1_0.isGreater(V1_2)).isFalse();
+		assertThat(RexsStandardVersions.V1_2.isGreater(RexsStandardVersions.V1_0)).isTrue();
+		assertThat(RexsStandardVersions.V1_0.isGreater(RexsStandardVersions.V1_2)).isFalse();
 	}
 
 	@Test
 	public void isLess_whenVersionIsLess_returnsTrue() {
-		assertThat(V1_0.isLess(V1_2)).isTrue();
-		assertThat(V1_2.isLess(V1_0)).isFalse();
+		assertThat(RexsStandardVersions.V1_0.isLess(RexsStandardVersions.V1_2)).isTrue();
+		assertThat(RexsStandardVersions.V1_2.isLess(RexsStandardVersions.V1_0)).isFalse();
 	}
 
 	@Test
 	public void isOneOf_whenVersionMatchesOneOfTheSpecifiedVersions_returnsTrue() {
-		assertThat(V1_1.isOneOf(V1_1, V1_2, V1_3)).isTrue();
-		assertThat(V1_2.isOneOf(V1_1, V1_2, V1_3)).isTrue();
-		assertThat(V1_3.isOneOf(V1_1, V1_2, V1_3)).isTrue();
+		assertThat(RexsStandardVersions.V1_1.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
+		assertThat(RexsStandardVersions.V1_2.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
+		assertThat(RexsStandardVersions.V1_3.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
 	}
 
 	@Test
 	public void isOneOf_whenVersionDoesNotMatchAnySpecifiedVersions_returnsFalse() {
-		assertThat(V1_4.isOneOf(V1_1, V1_2, V1_3)).isFalse();
+		assertThat(RexsStandardVersions.V1_4.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isFalse();
 	}
 }

--- a/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
@@ -15,70 +15,65 @@
  ******************************************************************************/
 package info.rexs.db.constants;
 
+import static info.rexs.db.constants.standard.RexsStandardVersions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.Test;
 
-import info.rexs.db.constants.standard.RexsStandardVersions;
-
 public class RexsVersionTest {
 
 	@Test
-	public void getLatest_returnsNotNull() throws Exception {
+	public void getLatest_returnsNotNull() {
 		assertThat(RexsVersion.getLatest()).isNotNull();
 	}
 
 	@Test
-	public void create_givenNullThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsVersion.create(null, 1);
-			})
+			.isThrownBy(() -> RexsVersion.create(null, 1))
 			.withMessage("name cannot be empty");
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsVersion.create("", 1);
-			})
+			.isThrownBy(() -> RexsVersion.create("", 1))
 			.withMessage("name cannot be empty");
 	}
 
 	@Test
-	public void create_givenNullAlternativeNamesDoesNotCrash() throws Exception {
+	public void create_givenNullAlternativeNamesDoesNotCrash() {
 		RexsVersion newVersion = RexsVersion.create("a.b", 1, (String[])null);
 		assertThat(newVersion.getName()).isEqualTo("a.b", 1);
 	}
 
 	@Test
-	public void create_newVersionHasName() throws Exception {
+	public void create_newVersionHasName() {
 		RexsVersion newVersion = RexsVersion.create("a.b", 1);
 		assertThat(newVersion.getName()).isEqualTo("a.b", 1);
 	}
 
 	@Test
 	public void findByName_givenNullReturnsUnknown() {
-		assertThat(RexsVersion.findByName(null)).isEqualTo(RexsStandardVersions.UNKNOWN);
+		assertThat(RexsVersion.findByName(null)).isEqualTo(UNKNOWN);
 	}
 
 	@Test
 	public void findByName_givenUnknownNameReturnsUnknown() {
-		assertThat(RexsVersion.findByName("foo.bar")).isEqualTo(RexsStandardVersions.UNKNOWN);
+		assertThat(RexsVersion.findByName("foo.bar")).isEqualTo(UNKNOWN);
 	}
 
 	@Test
-	public void findByName_returnsRexsStandardVersion() throws Exception {
-		RexsVersion version = RexsVersion.findByName(RexsStandardVersions.V1_0.getName());
+	public void findByName_returnsRexsStandardVersion() {
+		RexsVersion version = RexsVersion.findByName(V1_0.getName());
 		assertThat(version).isNotNull();
-		assertThat(version.getName()).isEqualTo(RexsStandardVersions.V1_0.getName());
+		assertThat(version.getName()).isEqualTo(V1_0.getName());
 	}
 
 	@Test
-	public void findByName_returnsNewlyCreatedVersion() throws Exception {
+	public void findByName_returnsNewlyCreatedVersion() {
 		RexsVersion.create("b.c", 1);
 		RexsVersion newVersion = RexsVersion.findByName("b.c");
 		assertThat(newVersion).isNotNull();
@@ -86,7 +81,7 @@ public class RexsVersionTest {
 	}
 
 	@Test
-	public void findByName_returnsNewlyCreatedVersionByAlternativeVersionName() throws Exception {
+	public void findByName_returnsNewlyCreatedVersionByAlternativeVersionName() {
 		RexsVersion.create("c.d", 1, "d.e", "e.f");
 
 		RexsVersion newVersionByName = RexsVersion.findByName("c.d");
@@ -100,5 +95,45 @@ public class RexsVersionTest {
 		newVersionByAlternativeName = RexsVersion.findByName("e.f");
 		assertThat(newVersionByAlternativeName).isNotNull();
 		assertThat(newVersionByAlternativeName.getName()).isEqualTo("c.d");
+	}
+
+	@Test
+	public void isLessOrEqual_whenVersionIsLessOrEqual_returnsTrue() {
+
+        assertThat(V1_0.isLessOrEqual(V1_1)).isTrue();
+		assertThat(V1_1.isLessOrEqual(V1_1)).isTrue();
+		assertThat(V1_2.isLessOrEqual(V1_1)).isFalse();
+	}
+
+	@Test
+	public void isEqual_whenVersionIsEqual_returnsTrue() {
+		RexsVersion V1_1_copy = RexsVersion.create("1.1", 1100);
+
+		assertThat(V1_1.isEqual(V1_1_copy)).isTrue();
+		assertThat(V1_1.isEqual(V1_1)).isTrue();
+	}
+
+	@Test
+	public void isGreater_whenVersionIsGreater_returnsTrue() {
+		assertThat(V1_2.isGreater(V1_0)).isTrue();
+		assertThat(V1_0.isGreater(V1_2)).isFalse();
+	}
+
+	@Test
+	public void isLess_whenVersionIsLess_returnsTrue() {
+		assertThat(V1_0.isLess(V1_2)).isTrue();
+		assertThat(V1_2.isLess(V1_0)).isFalse();
+	}
+
+	@Test
+	public void isOneOf_whenVersionMatchesOneOfTheSpecifiedVersions_returnsTrue() {
+		assertThat(V1_1.isOneOf(V1_1, V1_2, V1_3)).isTrue();
+		assertThat(V1_2.isOneOf(V1_1, V1_2, V1_3)).isTrue();
+		assertThat(V1_3.isOneOf(V1_1, V1_2, V1_3)).isTrue();
+	}
+
+	@Test
+	public void isOneOf_whenVersionDoesNotMatchAnySpecifiedVersions_returnsFalse() {
+		assertThat(V1_4.isOneOf(V1_1, V1_2, V1_3)).isFalse();
 	}
 }


### PR DESCRIPTION
The only content-wise change in this PR is the addition of `DEV` in `RexsStandardVersions`:
````java
    /**
     * Constant for the current development version.
     */
    RexsVersion DEV = RexsVersion.create("DEV", 9999);
````
The order `9999` will assure that this is always considered newer than any other version.

The rest of this PR is just housekeeping, completion of javadoc and increase of test coverage.