### PR TITLE
Adding missing "applicationLanguage" to XML and XSD

### DIFF
--- a/api/src/main/java/info/rexs/model/jaxb/Model.java
+++ b/api/src/main/java/info/rexs/model/jaxb/Model.java
@@ -37,6 +37,7 @@ import jakarta.xml.bind.annotation.XmlType;
  *       &lt;attribute name="applicationId" use="required" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
  *       &lt;attribute name="applicationVersion" use="required" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
  *       &lt;attribute name="date" use="required" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
+ *       &lt;attribute name="applicationLanguage" use="optional" type="{http://www.w3.org/2001/XMLSchema}string" /&gt;
  *     &lt;/restriction&gt;
  *   &lt;/complexContent&gt;
  * &lt;/complexType&gt;
@@ -65,6 +66,8 @@ public class Model {
     protected String applicationVersion;
     @XmlAttribute(name = "date", required = true)
     protected String date;
+    @XmlAttribute(name = "applicationLanguage", required = false)
+    protected String applicationLanguage;
 
     /**
      * Ruft den Wert der relations-Eigenschaft ab.
@@ -237,6 +240,30 @@ public class Model {
      */
     public void setDate(String value) {
         this.date = value;
+    }
+
+    /**
+     * Ruft den Wert der applicationLanguage-Eigenschaft ab.
+     *
+     * @return
+     *     possible object is
+     *     {@link String }
+     *
+     */
+    public String getApplicationLanguage() {
+        return applicationLanguage;
+    }
+
+    /**
+     * Legt den Wert der applicationLanguage-Eigenschaft fest.
+     *
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *
+     */
+    public void setApplicationLanguage(String value) {
+        this.applicationLanguage = value;
     }
 
 	public void setLoadSpectrum(LoadSpectrum loadSpectrum) {

--- a/api/src/main/resources/info/rexs/schema/rexs-file-ns.xsd
+++ b/api/src/main/resources/info/rexs/schema/rexs-file-ns.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
   Copyright (C) 2020 FVA GmbH
-  
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy
   of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -27,10 +27,11 @@
 				<xsd:element ref="components"    minOccurs="0" maxOccurs="1"/>
 				<xsd:element ref="load_spectrum" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
-			<xsd:attribute name="version"            type="xsd:string" use="required"/>
-			<xsd:attribute name="applicationId"      type="xsd:string" use="required"/>
-			<xsd:attribute name="applicationVersion" type="xsd:string" use="required"/>
-			<xsd:attribute name="date"               type="xsd:string" use="required"/>
+			<xsd:attribute name="version"             type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationId"       type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationVersion"  type="xsd:string" use="required"/>
+			<xsd:attribute name="date"                type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationLanguage" type="xsd:string" use="optional"/>
 			<xsd:anyAttribute processContents="skip"/>
 		</xsd:complexType>
 		<xsd:key          name="relationId">

--- a/api/src/main/resources/info/rexs/schema/rexs-file.xsd
+++ b/api/src/main/resources/info/rexs/schema/rexs-file.xsd
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
   Copyright (C) 2020 FVA GmbH
-  
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy
   of the License at
-  
+
     http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -36,10 +36,11 @@
 				<xsd:element ref="components"    minOccurs="0" maxOccurs="1"/>
 				<xsd:element ref="load_spectrum" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
-			<xsd:attribute name="version"            type="xsd:string" use="required"/>
-			<xsd:attribute name="applicationId"      type="xsd:string" use="required"/>
-			<xsd:attribute name="applicationVersion" type="xsd:string" use="required"/>
-			<xsd:attribute name="date"               type="xsd:string" use="required"/>
+			<xsd:attribute name="version"             type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationId"       type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationVersion"  type="xsd:string" use="required"/>
+			<xsd:attribute name="date"                type="xsd:string" use="required"/>
+			<xsd:attribute name="applicationLanguage" type="xsd:string" use="optional"/>
 			<xsd:anyAttribute processContents="skip"/>
 		</xsd:complexType>
 		<xsd:key          name="relationId">


### PR DESCRIPTION
This adds the missing `applicationLanguage` to the XSD files and the XML model definition.

Resolves #122 