### PR TITLE
fix: Copyright in classes as a normal comment

### DIFF
--- a/api/src/main/java/info/rexs/db/DbModelFile.java
+++ b/api/src/main/java/info/rexs/db/DbModelFile.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/db/DbModelFileResolver.java
+++ b/api/src/main/java/info/rexs/db/DbModelFileResolver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/db/DbModelRegistry.java
+++ b/api/src/main/java/info/rexs/db/DbModelRegistry.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import java.math.BigInteger;

--- a/api/src/main/java/info/rexs/db/DbModelResolver.java
+++ b/api/src/main/java/info/rexs/db/DbModelResolver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/db/IDbModelRegistry.java
+++ b/api/src/main/java/info/rexs/db/IDbModelRegistry.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import java.util.List;

--- a/api/src/main/java/info/rexs/db/constants/RexsAttributeId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsAttributeId.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.HashMap;

--- a/api/src/main/java/info/rexs/db/constants/RexsComponentType.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsComponentType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.HashMap;
@@ -50,7 +50,7 @@ public class RexsComponentType implements RexsStandardComponentTypes {
 	public String getId() {
 		return id;
 	}
-	
+
 	/**
 	 * @return
 	 * 				The actual ID of the component type as a {@link String}.

--- a/api/src/main/java/info/rexs/db/constants/RexsRelationRole.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsRelationRole.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.HashMap;

--- a/api/src/main/java/info/rexs/db/constants/RexsRelationType.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsRelationType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsUnitId.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.HashMap;

--- a/api/src/main/java/info/rexs/db/constants/RexsValueType.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsValueType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 /**

--- a/api/src/main/java/info/rexs/db/constants/RexsVersion.java
+++ b/api/src/main/java/info/rexs/db/constants/RexsVersion.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardAttributeIds.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardAttributeIds.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import javax.annotation.processing.Generated;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardComponentTypes.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardComponentTypes.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import javax.annotation.processing.Generated;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardRelationRoles.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardRelationRoles.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import javax.annotation.processing.Generated;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardRelationTypes.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardRelationTypes.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardUnitIds.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardUnitIds.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
+++ b/api/src/main/java/info/rexs/db/constants/standard/RexsStandardVersions.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants.standard;
 
 import info.rexs.db.constants.RexsVersion;

--- a/api/src/main/java/info/rexs/io/AbstractRexsFileReader.java
+++ b/api/src/main/java/info/rexs/io/AbstractRexsFileReader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/AbstractRexsFileWriter.java
+++ b/api/src/main/java/info/rexs/io/AbstractRexsFileWriter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/ByteArrayResource.java
+++ b/api/src/main/java/info/rexs/io/ByteArrayResource.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.ByteArrayInputStream;
@@ -24,7 +24,7 @@ public class ByteArrayResource implements Resource {
 	private final byte[] byteArray;
 
 	private final String filename;
-	
+
 	public ByteArrayResource(byte[] byteArray, String filename) {
 		this.byteArray = byteArray;
 		this.filename = filename;

--- a/api/src/main/java/info/rexs/io/FileResource.java
+++ b/api/src/main/java/info/rexs/io/FileResource.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.FileNotFoundException;
@@ -25,7 +25,7 @@ import java.nio.file.Path;
 public class FileResource implements Resource {
 
 	private final Path filePath;
-	
+
 	public FileResource(Path filePath) {
 		this.filePath = filePath;
 	}

--- a/api/src/main/java/info/rexs/io/Resource.java
+++ b/api/src/main/java/info/rexs/io/Resource.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.IOException;

--- a/api/src/main/java/info/rexs/io/RexsFileReader.java
+++ b/api/src/main/java/info/rexs/io/RexsFileReader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/RexsFileUpgrader.java
+++ b/api/src/main/java/info/rexs/io/RexsFileUpgrader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/RexsFileWriter.java
+++ b/api/src/main/java/info/rexs/io/RexsFileWriter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/RexsIoException.java
+++ b/api/src/main/java/info/rexs/io/RexsIoException.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 public class RexsIoException extends Exception {

--- a/api/src/main/java/info/rexs/io/RexsIoFormat.java
+++ b/api/src/main/java/info/rexs/io/RexsIoFormat.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import java.nio.file.Path;

--- a/api/src/main/java/info/rexs/io/json/RexsJsonFileReader.java
+++ b/api/src/main/java/info/rexs/io/json/RexsJsonFileReader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.json;
 
 import java.io.BufferedReader;

--- a/api/src/main/java/info/rexs/io/json/RexsJsonFileWriter.java
+++ b/api/src/main/java/info/rexs/io/json/RexsJsonFileWriter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.json;
 
 import java.io.BufferedWriter;

--- a/api/src/main/java/info/rexs/io/xml/RexsXmlFileReader.java
+++ b/api/src/main/java/info/rexs/io/xml/RexsXmlFileReader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.xml;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/xml/RexsXmlFileWriter.java
+++ b/api/src/main/java/info/rexs/io/xml/RexsXmlFileWriter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.xml;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/io/zip/RexsZipFileReader.java
+++ b/api/src/main/java/info/rexs/io/zip/RexsZipFileReader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.zip;
 
 import java.io.ByteArrayOutputStream;

--- a/api/src/main/java/info/rexs/io/zip/RexsZipFileWriter.java
+++ b/api/src/main/java/info/rexs/io/zip/RexsZipFileWriter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.zip;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/model/RexsAttribute.java
+++ b/api/src/main/java/info/rexs/model/RexsAttribute.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.time.OffsetDateTime;

--- a/api/src/main/java/info/rexs/model/RexsComponent.java
+++ b/api/src/main/java/info/rexs/model/RexsComponent.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.util.Collection;
@@ -101,7 +101,7 @@ public class RexsComponent implements Comparable<RexsComponent> {
 	public Integer getId() {
 		return id;
 	}
-	
+
 	/**
 	 * @return
 	 * 				The type of the component as {@link RexsComponentType}.
@@ -1031,7 +1031,7 @@ public class RexsComponent implements Comparable<RexsComponent> {
 	public boolean isOfType(RexsComponentType... rexsComponentTypes) {
 		return this.type.isOneOf(rexsComponentTypes);
 	}
-	
+
 	@Override
     public String toString() {
     	if (name!=null)
@@ -1041,9 +1041,9 @@ public class RexsComponent implements Comparable<RexsComponent> {
 
 	public void setId(Integer newCompId) {
 		if(newCompId != null)
-			this.id = newCompId;		
+			this.id = newCompId;
 	}
-	
+
 	public void setType(RexsComponentType newType) {
 		this.type = newType;
 	}

--- a/api/src/main/java/info/rexs/model/RexsLoadSpectrum.java
+++ b/api/src/main/java/info/rexs/model/RexsLoadSpectrum.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/RexsModel.java
+++ b/api/src/main/java/info/rexs/model/RexsModel.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/RexsModelAccessException.java
+++ b/api/src/main/java/info/rexs/model/RexsModelAccessException.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 /**

--- a/api/src/main/java/info/rexs/model/RexsModelObjectFactory.java
+++ b/api/src/main/java/info/rexs/model/RexsModelObjectFactory.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import info.rexs.db.constants.RexsAttributeId;

--- a/api/src/main/java/info/rexs/model/RexsRelation.java
+++ b/api/src/main/java/info/rexs/model/RexsRelation.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/RexsRelationRef.java
+++ b/api/src/main/java/info/rexs/model/RexsRelationRef.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import info.rexs.db.constants.RexsRelationRole;

--- a/api/src/main/java/info/rexs/model/RexsSubModel.java
+++ b/api/src/main/java/info/rexs/model/RexsSubModel.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import java.util.HashMap;
@@ -152,7 +152,7 @@ public class RexsSubModel implements Comparable<RexsSubModel> {
 					refCompAttribute.setStringValue(String.valueOf(newId));
 			}
 		}
-		
+
 	}
 
 	/**

--- a/api/src/main/java/info/rexs/model/transformer/IRexsModelTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/IRexsModelTransformer.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.transformer;
 
 import info.rexs.model.RexsModel;

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.transformer;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/util/Base64Utils.java
+++ b/api/src/main/java/info/rexs/model/util/Base64Utils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.util;
 
 import java.nio.ByteBuffer;
@@ -180,7 +180,7 @@ public class Base64Utils {
 
 	private static int[] flatIntMatrix(int[][] matrix) {
 		if (matrix.length==0)
-			return new int[0]; 
+			return new int[0];
 		int arrayLength = 0;
 		int numRows = matrix.length;
 		int numColumns =  matrix[0].length;
@@ -203,7 +203,7 @@ public class Base64Utils {
 
 	private static float[] flatFloatMatrix(float[][] matrix) {
 		if (matrix.length==0)
-			return new float[0]; 
+			return new float[0];
 		int arrayLength = 0;
 		int numRows = matrix.length;
 		int numColumns =  matrix[0].length;
@@ -221,7 +221,7 @@ public class Base64Utils {
 			}
 		}
 
-		return array;		
+		return array;
 	}
 
 	/**
@@ -229,7 +229,7 @@ public class Base64Utils {
 	 */
 	private static double[] flatDoubleMatrix(double[][] matrix) {
 		if (matrix.length==0)
-			return new double[0]; 
+			return new double[0];
 		int arrayLength = 0;
 		int numRows = matrix.length;
 		int numColumns =  matrix[0].length;
@@ -263,8 +263,8 @@ public class Base64Utils {
 	private static float[][] unflatFloatMatrix(float[] array, int rows, int cols) {
 		float[][] matrix = new float[rows][cols];
 		for (int i = 0; i < array.length; i++) {
-			int rowIndex = i % rows; 
-			int colIndex = i / rows; 
+			int rowIndex = i % rows;
+			int colIndex = i / rows;
 			matrix[rowIndex][colIndex] = array[i];
 		}
 		return matrix;

--- a/api/src/main/java/info/rexs/model/util/DateUtils.java
+++ b/api/src/main/java/info/rexs/model/util/DateUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.util;
 
 import java.text.DateFormat;

--- a/api/src/main/java/info/rexs/model/util/JavaDatatypeUtils.java
+++ b/api/src/main/java/info/rexs/model/util/JavaDatatypeUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.util;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValue.java
+++ b/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValue.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.time.OffsetDateTime;
@@ -29,7 +29,7 @@ public abstract class AbstractRexsAttributeValue {
 	public OffsetDateTime getValueDateTime() {
 		throw new RexsModelAccessException("attribute value is not available as ISO-8601 date-time");
 	}
-	
+
 	public boolean getValueBoolean() {
 		throw new RexsModelAccessException("attribute value is not available as a boolean");
 	}

--- a/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValueArray.java
+++ b/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValueArray.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.util.List;

--- a/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValueMatrix.java
+++ b/api/src/main/java/info/rexs/model/value/AbstractRexsAttributeValueMatrix.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.util.Arrays;

--- a/api/src/main/java/info/rexs/model/value/Base64Type.java
+++ b/api/src/main/java/info/rexs/model/value/Base64Type.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 public enum Base64Type {

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueArray.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueArray.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueArrayBase64.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueArrayBase64.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import info.rexs.model.util.Base64Utils;

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueArrayOfArrays.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueArrayOfArrays.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueMatrix.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueMatrix.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueMatrixBase64.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueMatrixBase64.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import info.rexs.model.RexsModelAccessException;

--- a/api/src/main/java/info/rexs/model/value/RexsAttributeValueScalar.java
+++ b/api/src/main/java/info/rexs/model/value/RexsAttributeValueScalar.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model.value;
 
 import java.time.OffsetDateTime;
@@ -29,7 +29,7 @@ public class RexsAttributeValueScalar extends AbstractRexsAttributeValue {
 	public RexsAttributeValueScalar(String value) {
 		this.value = value;
 	}
-	
+
 	@Override
 	public boolean hasValue() {
 		return value != null
@@ -47,7 +47,7 @@ public class RexsAttributeValueScalar extends AbstractRexsAttributeValue {
 		if(!value.equals("false")&&!value.equals("true")) {
 			throw new RexsModelAccessException("boolean value cannot be "+value);
 		}
-			
+
 		if (value != null && !value.isEmpty())
 			val = Boolean.valueOf(value);
 
@@ -117,7 +117,7 @@ public class RexsAttributeValueScalar extends AbstractRexsAttributeValue {
 	public void setValueTime(OffsetDateTime time) {
 		this.value = DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(time);
 	}
-	
+
 	public OffsetDateTime getValueDateTime() {
 		return OffsetDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 	}

--- a/api/src/main/java/info/rexs/schema/RexsSchema.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchema.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.schema;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/upgrade/RexsUpgradeException.java
+++ b/api/src/main/java/info/rexs/upgrade/RexsUpgradeException.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade;
 
 /**

--- a/api/src/main/java/info/rexs/upgrade/RexsUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/RexsUpgrader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgrader.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders;
 
 import info.rexs.model.RexsModel;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeResolver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders;
 
 import java.util.Collections;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders.changelog;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileResolver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders.changelog;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders.changelog;
 
 import java.io.InputStream;

--- a/api/src/main/java/info/rexs/validation/DefaultRexsAttributeValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsAttributeValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsAttribute;

--- a/api/src/main/java/info/rexs/validation/DefaultRexsComponentValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsComponentValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.HashSet;

--- a/api/src/main/java/info/rexs/validation/DefaultRexsFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsFileValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/validation/DefaultRexsModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsModelValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsComponent;

--- a/api/src/main/java/info/rexs/validation/DefaultRexsRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsRelationValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsModel;

--- a/api/src/main/java/info/rexs/validation/IRexsAttributeValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsAttributeValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsAttribute;

--- a/api/src/main/java/info/rexs/validation/IRexsComponentValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsComponentValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsComponent;

--- a/api/src/main/java/info/rexs/validation/IRexsFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsFileValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.io.File;

--- a/api/src/main/java/info/rexs/validation/IRexsModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsModelValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsModel;
@@ -45,7 +45,7 @@ public interface IRexsModelValidator {
 
 	/**
 	 * Creates a new validator for the relations of the REXS file.
-	 * 
+	 *
 	 * @return
 	 * 				The relation validator as {@link IRexsRelationValidator}.
 	 */

--- a/api/src/main/java/info/rexs/validation/IRexsRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsRelationValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.model.RexsModel;
@@ -30,7 +30,7 @@ public interface IRexsRelationValidator {
 	 *
 	 * @param rexsRelation
 	 * 				The REXS relation to validate.
-	 * @param rexsModel 
+	 * @param rexsModel
 	 *
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.

--- a/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticFileValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,13 +12,13 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import info.rexs.db.IDbModelRegistry;
 
 /**
- * This implementation of {@link IRexsFileValidator} validates if a REXS file conforms to the 
+ * This implementation of {@link IRexsFileValidator} validates if a REXS file conforms to the
  * modelling guideline quasistatic and includes the specification of official REXS versions.
  *
  * @author FVA GmbH

--- a/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticModelValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.HashSet;

--- a/api/src/main/java/info/rexs/validation/RexsStandardAttributeValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardAttributeValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.Objects;

--- a/api/src/main/java/info/rexs/validation/RexsStandardComponentValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardComponentValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.Objects;

--- a/api/src/main/java/info/rexs/validation/RexsStandardFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardFileValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.Objects;

--- a/api/src/main/java/info/rexs/validation/RexsStandardModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardModelValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.List;

--- a/api/src/main/java/info/rexs/validation/RexsStandardRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardRelationValidator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.HashMap;

--- a/api/src/main/java/info/rexs/validation/RexsValidationResult.java
+++ b/api/src/main/java/info/rexs/validation/RexsValidationResult.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 import java.util.ArrayList;

--- a/api/src/main/java/info/rexs/validation/RexsValidationResultMessage.java
+++ b/api/src/main/java/info/rexs/validation/RexsValidationResultMessage.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2024 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 /**

--- a/api/src/main/java/info/rexs/validation/RexsValidationResultMessageKey.java
+++ b/api/src/main/java/info/rexs/validation/RexsValidationResultMessageKey.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.validation;
 
 /**

--- a/api/src/test/java/info/rexs/db/DbModelFileTest.java
+++ b/api/src/test/java/info/rexs/db/DbModelFileTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/DbModelResolverTest.java
+++ b/api/src/test/java/info/rexs/db/DbModelResolverTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsAttributeIdTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsAttributeIdTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsComponentTypeTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsComponentTypeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsRelationRoleTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsRelationRoleTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsRelationTypeTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsRelationTypeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsUnitIdTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsUnitIdTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsValueTypeTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsValueTypeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/db/constants/RexsVersionTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.db.constants;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/RexsFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/RexsFileReaderTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/RexsFileUpgraderTest.java
+++ b/api/src/test/java/info/rexs/io/RexsFileUpgraderTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/RexsFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/RexsFileWriterTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/json/RexsJsonFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/json/RexsJsonFileReaderTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.json;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/json/RexsJsonFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/json/RexsJsonFileWriterTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +78,7 @@ public class RexsJsonFileWriterTest {
 
 		RexsFileReader reader = new RexsFileReader(rexsInputFileStringPath);
 		RexsModel model = aRexsModelToWrite = reader.read();
-	
+
 		RexsJsonFileWriter writer = new RexsJsonFileWriter(rexsOutputFileStringPath);
 		writer.write(model);
 

--- a/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/xml/RexsXmlFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/xml/RexsXmlFileWriterTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/zip/RexsZipFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/zip/RexsZipFileReaderTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.zip;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/io/zip/RexsZipFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/zip/RexsZipFileWriterTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2023 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.io.zip;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/model/RexsAttributeTest.java
+++ b/api/src/test/java/info/rexs/model/RexsAttributeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/model/RexsComponentTest.java
+++ b/api/src/test/java/info/rexs/model/RexsComponentTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/model/RexsModelAccessExceptionTest.java
+++ b/api/src/test/java/info/rexs/model/RexsModelAccessExceptionTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/model/RexsRelationRefTest.java
+++ b/api/src/test/java/info/rexs/model/RexsRelationRefTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/model/RexsSubModelTest.java
+++ b/api/src/test/java/info/rexs/model/RexsSubModelTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/upgrade/RexsUpgradeExceptionTest.java
+++ b/api/src/test/java/info/rexs/upgrade/RexsUpgradeExceptionTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders.changelog;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright (C) 2020 FVA GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -12,7 +12,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- ******************************************************************************/
+ */
 package info.rexs.upgrade.upgraders.changelog;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This pull request fixes the copyright information in all Java classes. The redundant '*' characters are removed to make it a normal comment.