### PR TITLE
added editorconfig file for cross-IDE formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 160
+tab_width = 4
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+
+[{*.yaml,*.yml}]
+indent_size = 2
+
+[*.xml]
+max_line_length = off
+
+[*.xsd]
+max_line_length = off
+indent_style = tab

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,16 @@
 {
+    "editor.rulers": [
+        160
+    ],
     "java.configuration.updateBuildConfiguration": "interactive",
-    "java.dependency.packagePresentation": "flat"
+    "java.dependency.packagePresentation": "flat",
+    "prettier.printWidth": 160,
+    "[xml]": {
+        "editor.rulers": [],
+        "prettier.printWidth": null
+    },
+    "[xsd]": {
+        "editor.rulers": [],
+        "prettier.printWidth": null
+    }
 }


### PR DESCRIPTION
see #128

Unfortunately, `.editorconfig` only allows to set a few basic formatting options. However, it is a good baseline for generics such als indentation, max. line length, enconding and line endings. 

The file is reflecting the current formatting, so only miminal changes should happen due to using this in the future.