### PR TITLE
Added numericId to components in schema files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Using JAXB to generate data classes
 - Renaming default branch from "master" to "main"
 - Changed class types on data classes from `BigInteger` and `BigDecimal` to `int` and `double`
+- Added numericId to components in schema files
 
 
 ## [0.9.0] - 2024-10-23

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.0.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.0.xml
@@ -80,33 +80,33 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="2"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="3"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="4"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="5"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="6"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="7"/>
-        <component componentId="fixed_coupling" nameEn="Non-switchable coupling" nameDe="Nicht-schaltbare Kupplung" databaseId="8"/>
-        <component componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="9"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="10"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="11"/>
-        <component componentId="general_gear" nameEn="General gear" nameDe="Zahnrad" databaseId="12"/>
-        <component componentId="general_stage" nameEn="General stage" nameDe="Zahnradstufe" databaseId="13"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="14"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="15"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="16"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="17"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="18"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="19"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="20"/>
-        <component componentId="root" nameEn="Model" nameDe="Modell" databaseId="21"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="22"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="23"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="24"/>
-        <component componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="25"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="26"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="27"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="2"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="3"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="4"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="5"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="6"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="7"/>
+        <component numericId="8" componentId="fixed_coupling" nameEn="Non-switchable coupling" nameDe="Nicht-schaltbare Kupplung" databaseId="8"/>
+        <component numericId="9" componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="9"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="10"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="11"/>
+        <component numericId="12" componentId="general_gear" nameEn="General gear" nameDe="Zahnrad" databaseId="12"/>
+        <component numericId="13" componentId="general_stage" nameEn="General stage" nameDe="Zahnradstufe" databaseId="13"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="14"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="15"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="16"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="17"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="18"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="19"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="20"/>
+        <component numericId="21" componentId="root" nameEn="Model" nameDe="Modell" databaseId="21"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="22"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="23"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="24"/>
+        <component numericId="25" componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="25"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="26"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="27"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 431" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="232"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.1.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.1.xml
@@ -80,36 +80,36 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="103"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="104"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="105"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="106"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="107"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="108"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="109"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="110"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="111"/>
-        <component componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="112"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="113"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="114"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="115"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="116"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="117"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="118"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="119"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="120"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="121"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="122"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="123"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="124"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="125"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="126"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="127"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="128"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="129"/>
-        <component componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="130"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="131"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="132"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="103"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="104"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="105"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="106"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="107"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="108"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="109"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="110"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="111"/>
+        <component numericId="9" componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="112"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="113"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="114"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="115"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="116"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="117"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="118"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="119"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="120"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="121"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="122"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="123"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="124"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="125"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="126"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="127"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="128"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="129"/>
+        <component numericId="25" componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="130"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="131"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="132"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="1643"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.2.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.2.xml
@@ -80,53 +80,53 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="161"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="162"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="163"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="164"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="165"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="166"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="167"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="168"/>
-        <component componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="197"/>
-        <component componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="199"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="169"/>
-        <component componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="170"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="171"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="172"/>
-        <component componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="196"/>
-        <component componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="204"/>
-        <component componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="195"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="173"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="174"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="175"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="176"/>
-        <component componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="194"/>
-        <component componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="203"/>
-        <component componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="193"/>
-        <component componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="205"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="177"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="178"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="179"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="180"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="181"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="182"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="183"/>
-        <component componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="192"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="184"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="185"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="186"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="187"/>
-        <component componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="188"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="189"/>
-        <component componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="191"/>
-        <component componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="198"/>
-        <component componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="207"/>
-        <component componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="206"/>
-        <component componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="201"/>
-        <component componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="200"/>
-        <component componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="202"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="190"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="161"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="162"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="163"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="164"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="165"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="166"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="167"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="168"/>
+        <component numericId="43" componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="197"/>
+        <component numericId="55" componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="199"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="169"/>
+        <component numericId="9" componentId="flank_geometry" nameEn="Tooth flank" nameDe="Zahnflanke" databaseId="170"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="171"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="172"/>
+        <component numericId="42" componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="196"/>
+        <component numericId="60" componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="204"/>
+        <component numericId="41" componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="195"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="173"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="174"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="175"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="176"/>
+        <component numericId="40" componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="194"/>
+        <component numericId="59" componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="203"/>
+        <component numericId="39" componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="193"/>
+        <component numericId="61" componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="205"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="177"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="178"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="179"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="180"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="181"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="182"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="183"/>
+        <component numericId="38" componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="192"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="184"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="185"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="186"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="187"/>
+        <component numericId="25" componentId="stage_gear_data" nameEn="Stage gear data" nameDe="Radbezogene Eingriffsdaten" databaseId="188"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="189"/>
+        <component numericId="37" componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="191"/>
+        <component numericId="44" componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="198"/>
+        <component numericId="63" componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="207"/>
+        <component numericId="62" componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="206"/>
+        <component numericId="57" componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="201"/>
+        <component numericId="56" componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="200"/>
+        <component numericId="58" componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="202"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="190"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="2265"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.3.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.3.xml
@@ -80,71 +80,71 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="729"/>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="730"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="731"/>
-        <component componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="732"/>
-        <component componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="733"/>
-        <component componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="734"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="735"/>
-        <component componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="736"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="737"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="738"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="739"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="740"/>
-        <component componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="741"/>
-        <component componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="742"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="743"/>
-        <component componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="744"/>
-        <component componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="745"/>
-        <component componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="746"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="747"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="748"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="749"/>
-        <component componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="750"/>
-        <component componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="751"/>
-        <component componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="752"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="753"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="754"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="755"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="756"/>
-        <component componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="757"/>
-        <component componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="758"/>
-        <component componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="759"/>
-        <component componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="760"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="761"/>
-        <component componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="762"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="763"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="764"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="765"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="766"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="767"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="768"/>
-        <component componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="769"/>
-        <component componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="770"/>
-        <component componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="771"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="772"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="773"/>
-        <component componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="774"/>
-        <component componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="775"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="776"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="777"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="779"/>
-        <component componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="780"/>
-        <component componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="781"/>
-        <component componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="782"/>
-        <component componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="783"/>
-        <component componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="784"/>
-        <component componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="785"/>
-        <component componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="786"/>
-        <component componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="787"/>
-        <component componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="788"/>
-        <component componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="789"/>
-        <component componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="790"/>
-        <component componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="791"/>
-        <component componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="792"/>
-        <component componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="793"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="794"/>
+        <component numericId="82" componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="729"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="730"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="731"/>
+        <component numericId="80" componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="732"/>
+        <component numericId="84" componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="733"/>
+        <component numericId="86" componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="734"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="735"/>
+        <component numericId="77" componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="736"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="737"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="738"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="739"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="740"/>
+        <component numericId="79" componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="741"/>
+        <component numericId="83" componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="742"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="743"/>
+        <component numericId="76" componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="744"/>
+        <component numericId="43" componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="745"/>
+        <component numericId="55" componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="746"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="747"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="748"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="749"/>
+        <component numericId="42" componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="750"/>
+        <component numericId="60" componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="751"/>
+        <component numericId="41" componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="752"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="753"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="754"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="755"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="756"/>
+        <component numericId="40" componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="757"/>
+        <component numericId="59" componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="758"/>
+        <component numericId="39" componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="759"/>
+        <component numericId="61" componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="760"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="761"/>
+        <component numericId="70" componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="762"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="763"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="764"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="765"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="766"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="767"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="768"/>
+        <component numericId="66" componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="769"/>
+        <component numericId="38" componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="770"/>
+        <component numericId="69" componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="771"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="772"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="773"/>
+        <component numericId="67" componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="774"/>
+        <component numericId="68" componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="775"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="776"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="777"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="779"/>
+        <component numericId="37" componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="780"/>
+        <component numericId="44" componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="781"/>
+        <component numericId="72" componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="782"/>
+        <component numericId="63" componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="783"/>
+        <component numericId="62" componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="784"/>
+        <component numericId="71" componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="785"/>
+        <component numericId="57" componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="786"/>
+        <component numericId="81" componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="787"/>
+        <component numericId="85" componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="788"/>
+        <component numericId="73" componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="789"/>
+        <component numericId="56" componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="790"/>
+        <component numericId="78" componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="791"/>
+        <component numericId="58" componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="792"/>
+        <component numericId="74" componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="793"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="794"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="10879"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.4.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.4.xml
@@ -80,90 +80,90 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1055"/>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1056"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1057"/>
-        <component componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1058"/>
-        <component componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1059"/>
-        <component componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1060"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1061"/>
-        <component componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1062"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1063"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1064"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1065"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1066"/>
-        <component componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1067"/>
-        <component componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1068"/>
-        <component componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1069"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1070"/>
-        <component componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1071"/>
-        <component componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1072"/>
-        <component componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1073"/>
-        <component componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1074"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1075"/>
-        <component componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1076"/>
-        <component componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1077"/>
-        <component componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1078"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1079"/>
-        <component componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1080"/>
-        <component componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1081"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1082"/>
-        <component componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1083"/>
-        <component componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1084"/>
-        <component componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1085"/>
-        <component componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1086"/>
-        <component componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1087"/>
-        <component componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1088"/>
-        <component componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1089"/>
-        <component componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1090"/>
-        <component componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1091"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1092"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1093"/>
-        <component componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1094"/>
-        <component componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1095"/>
-        <component componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1096"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1097"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1098"/>
-        <component componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1099"/>
-        <component componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1100"/>
-        <component componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1101"/>
-        <component componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1102"/>
-        <component componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1103"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1104"/>
-        <component componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1105"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1106"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1107"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1108"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1109"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1110"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1111"/>
-        <component componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1112"/>
-        <component componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1113"/>
-        <component componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1114"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1115"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1116"/>
-        <component componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1117"/>
-        <component componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1118"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1119"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1120"/>
-        <component componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1121"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1122"/>
-        <component componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1123"/>
-        <component componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1124"/>
-        <component componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1125"/>
-        <component componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1126"/>
-        <component componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1127"/>
-        <component componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1128"/>
-        <component componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1129"/>
-        <component componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1130"/>
-        <component componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1131"/>
-        <component componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1132"/>
-        <component componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1133"/>
-        <component componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1134"/>
-        <component componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1135"/>
-        <component componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1136"/>
-        <component componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1137"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1138"/>
+        <component numericId="82" componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1055"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1056"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1057"/>
+        <component numericId="80" componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1058"/>
+        <component numericId="84" componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1059"/>
+        <component numericId="86" componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1060"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1061"/>
+        <component numericId="77" componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1062"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1063"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1064"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1065"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1066"/>
+        <component numericId="79" componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1067"/>
+        <component numericId="83" componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1068"/>
+        <component numericId="96" componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1069"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1070"/>
+        <component numericId="76" componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1071"/>
+        <component numericId="90" componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1072"/>
+        <component numericId="43" componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1073"/>
+        <component numericId="55" componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1074"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1075"/>
+        <component numericId="87" componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1076"/>
+        <component numericId="99" componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1077"/>
+        <component numericId="65" componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1078"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1079"/>
+        <component numericId="92" componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1080"/>
+        <component numericId="91" componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1081"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1082"/>
+        <component numericId="42" componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1083"/>
+        <component numericId="60" componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1084"/>
+        <component numericId="41" componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1085"/>
+        <component numericId="100" componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1086"/>
+        <component numericId="104" componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1087"/>
+        <component numericId="102" componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1088"/>
+        <component numericId="101" componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1089"/>
+        <component numericId="103" componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1090"/>
+        <component numericId="95" componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1091"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1092"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1093"/>
+        <component numericId="93" componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1094"/>
+        <component numericId="94" componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1095"/>
+        <component numericId="98" componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1096"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1097"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1098"/>
+        <component numericId="89" componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1099"/>
+        <component numericId="40" componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1100"/>
+        <component numericId="59" componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1101"/>
+        <component numericId="39" componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1102"/>
+        <component numericId="61" componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1103"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1104"/>
+        <component numericId="70" componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1105"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1106"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1107"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1108"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1109"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1110"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1111"/>
+        <component numericId="66" componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1112"/>
+        <component numericId="38" componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1113"/>
+        <component numericId="69" componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1114"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1115"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1116"/>
+        <component numericId="67" componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1117"/>
+        <component numericId="68" componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1118"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1119"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1120"/>
+        <component numericId="88" componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1121"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1122"/>
+        <component numericId="97" componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1123"/>
+        <component numericId="37" componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1124"/>
+        <component numericId="44" componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1125"/>
+        <component numericId="72" componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1126"/>
+        <component numericId="63" componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1127"/>
+        <component numericId="62" componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1128"/>
+        <component numericId="71" componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1129"/>
+        <component numericId="57" componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1130"/>
+        <component numericId="81" componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1131"/>
+        <component numericId="85" componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1132"/>
+        <component numericId="73" componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1133"/>
+        <component numericId="56" componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1134"/>
+        <component numericId="78" componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1135"/>
+        <component numericId="58" componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1136"/>
+        <component numericId="74" componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1137"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1138"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="17009"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.5.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.5.xml
@@ -81,90 +81,90 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1139"/>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1140"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1141"/>
-        <component componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1142"/>
-        <component componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1143"/>
-        <component componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1144"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1145"/>
-        <component componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1146"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1147"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1148"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1149"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1150"/>
-        <component componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1151"/>
-        <component componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1152"/>
-        <component componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1153"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1154"/>
-        <component componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1155"/>
-        <component componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1156"/>
-        <component componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1157"/>
-        <component componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1158"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1159"/>
-        <component componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1160"/>
-        <component componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1161"/>
-        <component componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1162"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1163"/>
-        <component componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1164"/>
-        <component componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1165"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1166"/>
-        <component componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1167"/>
-        <component componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1168"/>
-        <component componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1169"/>
-        <component componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1170"/>
-        <component componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1171"/>
-        <component componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1172"/>
-        <component componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1173"/>
-        <component componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1174"/>
-        <component componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1175"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1176"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1177"/>
-        <component componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1178"/>
-        <component componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1179"/>
-        <component componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1180"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1181"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1182"/>
-        <component componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1183"/>
-        <component componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1184"/>
-        <component componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1185"/>
-        <component componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1186"/>
-        <component componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1187"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1188"/>
-        <component componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1189"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1190"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1191"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1192"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1193"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1194"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1195"/>
-        <component componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1196"/>
-        <component componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1197"/>
-        <component componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1198"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1199"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1200"/>
-        <component componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1201"/>
-        <component componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1202"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1203"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1204"/>
-        <component componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1205"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1206"/>
-        <component componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1207"/>
-        <component componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1208"/>
-        <component componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1209"/>
-        <component componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1210"/>
-        <component componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1211"/>
-        <component componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1212"/>
-        <component componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1213"/>
-        <component componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1214"/>
-        <component componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1215"/>
-        <component componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1216"/>
-        <component componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1217"/>
-        <component componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1218"/>
-        <component componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1219"/>
-        <component componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1220"/>
-        <component componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1221"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1222"/>
+        <component numericId="82" componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1139"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1140"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1141"/>
+        <component numericId="80" componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1142"/>
+        <component numericId="84" componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1143"/>
+        <component numericId="86" componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1144"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1145"/>
+        <component numericId="77" componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1146"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1147"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1148"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1149"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1150"/>
+        <component numericId="79" componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1151"/>
+        <component numericId="83" componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1152"/>
+        <component numericId="96" componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1153"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1154"/>
+        <component numericId="76" componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1155"/>
+        <component numericId="90" componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1156"/>
+        <component numericId="43" componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1157"/>
+        <component numericId="55" componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1158"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1159"/>
+        <component numericId="87" componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1160"/>
+        <component numericId="99" componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1161"/>
+        <component numericId="65" componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1162"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1163"/>
+        <component numericId="92" componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1164"/>
+        <component numericId="91" componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1165"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1166"/>
+        <component numericId="42" componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1167"/>
+        <component numericId="60" componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1168"/>
+        <component numericId="41" componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1169"/>
+        <component numericId="100" componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1170"/>
+        <component numericId="104" componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1171"/>
+        <component numericId="102" componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1172"/>
+        <component numericId="101" componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1173"/>
+        <component numericId="103" componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1174"/>
+        <component numericId="95" componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1175"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1176"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1177"/>
+        <component numericId="93" componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1178"/>
+        <component numericId="94" componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1179"/>
+        <component numericId="98" componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1180"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1181"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1182"/>
+        <component numericId="89" componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1183"/>
+        <component numericId="40" componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1184"/>
+        <component numericId="59" componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1185"/>
+        <component numericId="39" componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1186"/>
+        <component numericId="61" componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1187"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1188"/>
+        <component numericId="70" componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1189"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1190"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1191"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1192"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1193"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1194"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1195"/>
+        <component numericId="66" componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1196"/>
+        <component numericId="38" componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1197"/>
+        <component numericId="69" componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1198"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1199"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1200"/>
+        <component numericId="67" componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1201"/>
+        <component numericId="68" componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1202"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1203"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1204"/>
+        <component numericId="88" componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1205"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1206"/>
+        <component numericId="97" componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1207"/>
+        <component numericId="37" componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1208"/>
+        <component numericId="44" componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1209"/>
+        <component numericId="72" componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1210"/>
+        <component numericId="63" componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1211"/>
+        <component numericId="62" componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1212"/>
+        <component numericId="71" componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1213"/>
+        <component numericId="57" componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1214"/>
+        <component numericId="81" componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1215"/>
+        <component numericId="85" componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1216"/>
+        <component numericId="73" componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1217"/>
+        <component numericId="56" componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1218"/>
+        <component numericId="78" componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1219"/>
+        <component numericId="58" componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1220"/>
+        <component numericId="74" componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1221"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1222"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="18706"/>

--- a/api/src/main/resources/info/rexs/schema/rexs_schema_1.6.xml
+++ b/api/src/main/resources/info/rexs/schema/rexs_schema_1.6.xml
@@ -83,101 +83,101 @@
         <valueType id="17" name="string_matrix"/>
     </valueTypes>
     <components>
-        <component componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1576"/>
-        <component componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1577"/>
-        <component componentId="bearing_ring" nameEn="Bearing ring" nameDe="Lagerring" databaseId="1667"/>
-        <component componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1578"/>
-        <component componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1579"/>
-        <component componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1580"/>
-        <component componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1581"/>
-        <component componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1582"/>
-        <component componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1583"/>
-        <component componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1584"/>
-        <component componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1585"/>
-        <component componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1586"/>
-        <component componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1587"/>
-        <component componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1588"/>
-        <component componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1589"/>
-        <component componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1590"/>
-        <component componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1591"/>
-        <component componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1592"/>
-        <component componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1593"/>
-        <component componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1594"/>
-        <component componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1595"/>
-        <component componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1596"/>
-        <component componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1597"/>
-        <component componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1598"/>
-        <component componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1599"/>
-        <component componentId="gear_body" nameEn="Gear body" nameDe="Radkörper" databaseId="1668"/>
-        <component componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1600"/>
-        <component componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1601"/>
-        <component componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1602"/>
-        <component componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1603"/>
-        <component componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1604"/>
-        <component componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1605"/>
-        <component componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1606"/>
-        <component componentId="hydrodynamic_radial_plain_bearing" nameEn="Hydrodynamic radial plain bearing" nameDe="Hydrodynamisches Radialgleitlager" databaseId="1665"/>
-        <component componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1607"/>
-        <component componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1608"/>
-        <component componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1609"/>
-        <component componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1610"/>
-        <component componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1611"/>
-        <component componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1612"/>
-        <component componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1613"/>
-        <component componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1614"/>
-        <component componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1615"/>
-        <component componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1616"/>
-        <component componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1617"/>
-        <component componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1618"/>
-        <component componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1619"/>
-        <component componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1620"/>
-        <component componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1621"/>
-        <component componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1622"/>
-        <component componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1623"/>
-        <component componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1624"/>
-        <component componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1625"/>
-        <component componentId="radial_plain_bearing_groove" nameEn="Plain bearing groove" nameDe="Gleitlagernut" databaseId="1664"/>
-        <component componentId="radial_plain_bearing_hole" nameEn="Plain bearing hole" nameDe="Gleitlagerbohrung" databaseId="1662"/>
-        <component componentId="radial_plain_bearing_profile" nameEn="Plain bearing profile" nameDe="Gleitlagerprofil" databaseId="1661"/>
-        <component componentId="radial_plain_bearing_profile_data_set" nameEn="Plain bearing profiel data set" nameDe="Gleitlager-Profildatensatz" databaseId="1666"/>
-        <component componentId="radial_plain_bearing_shell" nameEn="Plain bearing shell" nameDe="Gleitlagerschale" databaseId="1660"/>
-        <component componentId="radial_plain_bearing_slot" nameEn="Plain bearing slot" nameDe="Hydrostatische Tasche" databaseId="1663"/>
-        <component componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1626"/>
-        <component componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1627"/>
-        <component componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1628"/>
-        <component componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1629"/>
-        <component componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1630"/>
-        <component componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1631"/>
-        <component componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1632"/>
-        <component componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1633"/>
-        <component componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1634"/>
-        <component componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1635"/>
-        <component componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1636"/>
-        <component componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1637"/>
-        <component componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1638"/>
-        <component componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1639"/>
-        <component componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1640"/>
-        <component componentId="sleeve" nameEn="Sleeve" nameDe="Hülse" databaseId="1669"/>
-        <component componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1641"/>
-        <component componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1642"/>
-        <component componentId="surface_contact" nameEn="Surface contact" nameDe="Oberflächenkontakt" databaseId="1670"/>
-        <component componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1643"/>
-        <component componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1644"/>
-        <component componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1645"/>
-        <component componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1646"/>
-        <component componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1647"/>
-        <component componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1648"/>
-        <component componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1649"/>
-        <component componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1650"/>
-        <component componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1651"/>
-        <component componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1652"/>
-        <component componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1653"/>
-        <component componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1654"/>
-        <component componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1655"/>
-        <component componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1656"/>
-        <component componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1657"/>
-        <component componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1658"/>
-        <component componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1659"/>
+        <component numericId="82" componentId="additional_mass" nameEn="Additional mass" nameDe="Zusatzmasse" databaseId="1576"/>
+        <component numericId="34" componentId="assembly_group" nameEn="Assembly group" nameDe="Baugruppe" databaseId="1577"/>
+        <component numericId="112" componentId="bearing_ring" nameEn="Bearing ring" nameDe="Lagerring" databaseId="1667"/>
+        <component numericId="1" componentId="bevel_gear" nameEn="Bevel gear" nameDe="Kegelrad" databaseId="1578"/>
+        <component numericId="80" componentId="bevel_gear_flank" nameEn="Flank of bevel gear" nameDe="Flanke eines Kegelrades" databaseId="1579"/>
+        <component numericId="84" componentId="bevel_gear_manufacturing_settings" nameEn="Bevel gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Kegelrädern" databaseId="1580"/>
+        <component numericId="86" componentId="bevel_gear_tool" nameEn="Bevel gear tool" nameDe="Kegelrad Messer" databaseId="1581"/>
+        <component numericId="2" componentId="bevel_stage" nameEn="Bevel stage" nameDe="Kegelradstufe" databaseId="1582"/>
+        <component numericId="77" componentId="bevel_stage_gear_data" nameEn="Bevel stage gear data" nameDe="Kegelradbezogene Eingriffsdaten" databaseId="1583"/>
+        <component numericId="3" componentId="concept_bearing" nameEn="Concept bearing" nameDe="Konzeptlager" databaseId="1584"/>
+        <component numericId="28" componentId="coupling" nameEn="Coupling" nameDe="Koppelstelle" databaseId="1585"/>
+        <component numericId="4" componentId="cutter_wheel_tool" nameEn="Cutter wheel tool" nameDe="Schneidrad" databaseId="1586"/>
+        <component numericId="5" componentId="cylindrical_gear" nameEn="Cylindrical gear" nameDe="Stirnrad" databaseId="1587"/>
+        <component numericId="79" componentId="cylindrical_gear_flank" nameEn="Flank of cylindrical gear" nameDe="Flanke eines Stirnrad" databaseId="1588"/>
+        <component numericId="83" componentId="cylindrical_gear_manufacturing_settings" nameEn="Cylindrical gear manufacturing settings" nameDe="Einstellungen für die Herstellung von Stirnrädern" databaseId="1589"/>
+        <component numericId="96" componentId="cylindrical_interference_fit" nameEn="Cylindrical interference fit" nameDe="Zylindrischer Pressverband" databaseId="1590"/>
+        <component numericId="6" componentId="cylindrical_stage" nameEn="Cylindrical stage" nameDe="Stirnradstufe" databaseId="1591"/>
+        <component numericId="76" componentId="cylindrical_stage_gear_data" nameEn="Cylindrical stage gear data" nameDe="Stirnradbezogene Eingriffsdaten" databaseId="1592"/>
+        <component numericId="90" componentId="element_list" nameEn="Element list" nameDe="Elementliste" databaseId="1593"/>
+        <component numericId="43" componentId="end_relief_datum_face" nameEn="End relief datum face" nameDe="Endrücknahme Bezugsseite" databaseId="1594"/>
+        <component numericId="55" componentId="end_relief_non_datum_face" nameEn="End relief non-datum face" nameDe="Endrücknahme Nicht-Bezugsseite" databaseId="1595"/>
+        <component numericId="7" componentId="external_load" nameEn="External load" nameDe="Externe Belastung" databaseId="1596"/>
+        <component numericId="87" componentId="feather_key_connection" nameEn="Feather key connection" nameDe="Passfederverbindung" databaseId="1597"/>
+        <component numericId="99" componentId="fem_data_set" nameEn="FEM data set" nameDe="FEM-Daten" databaseId="1598"/>
+        <component numericId="65" componentId="fkm_evaluation_point" nameEn="FKM evaluation point" nameDe="Auswertepunkt FKM" databaseId="1599"/>
+        <component numericId="113" componentId="gear_body" nameEn="Gear body" nameDe="Radkörper" databaseId="1668"/>
+        <component numericId="10" componentId="gear_casing" nameEn="Gear casing" nameDe="Gehäuse" databaseId="1600"/>
+        <component numericId="92" componentId="gear_flank_data_set" nameEn="Gear flank data of a point list" nameDe="Zahnflankendaten einer Punkteliste" databaseId="1601"/>
+        <component numericId="91" componentId="gear_root_data_set" nameEn="Gear root data of a point list" nameDe="Zahnfußdaten einer Punkteliste" databaseId="1602"/>
+        <component numericId="11" componentId="gear_unit" nameEn="Gear unit" nameDe="Getriebeeinheit" databaseId="1603"/>
+        <component numericId="42" componentId="helix_crowning" nameEn="Helix crowning" nameDe="Flankenlinien-Balligkeit" databaseId="1604"/>
+        <component numericId="60" componentId="helix_deviation" nameEn="Helix deviation" nameDe="Flankenlinien-Abweichung" databaseId="1605"/>
+        <component numericId="41" componentId="helix_slope" nameEn="Helix slope" nameDe="Flankenlinien-Winkelmodifikation" databaseId="1606"/>
+        <component numericId="110" componentId="hydrodynamic_radial_plain_bearing" nameEn="Hydrodynamic radial plain bearing" nameDe="Hydrodynamisches Radialgleitlager" databaseId="1665"/>
+        <component numericId="100" componentId="involute_spline_connection" nameEn="Involute spline connection" nameDe="Evolventische Passverzahnung" databaseId="1607"/>
+        <component numericId="104" componentId="involute_spline_gear_flank" nameEn="Involute spline gear flank" nameDe="Zahnflanke eines Passverzahnungsrades" databaseId="1608"/>
+        <component numericId="102" componentId="involute_spline_gear_hub" nameEn="Involute spline gear hub" nameDe="Evolventische Zahnnabe" databaseId="1609"/>
+        <component numericId="101" componentId="involute_spline_gear_shaft" nameEn="Involute spline gear shaft" nameDe="Evolventische Zahnwelle" databaseId="1610"/>
+        <component numericId="103" componentId="involute_spline_stage_gear_data" nameEn="Involute spline stage gear data" nameDe="Radbezogene Eingriffsdaten (Evolventische Passverzahnung)" databaseId="1611"/>
+        <component numericId="95" componentId="joint_section" nameEn="Joint section" nameDe="Fugenabschnitt" databaseId="1612"/>
+        <component numericId="14" componentId="lubricant" nameEn="Lubricant" nameDe="Schmierstoff" databaseId="1613"/>
+        <component numericId="15" componentId="material" nameEn="Material" nameDe="Werkstoff" databaseId="1614"/>
+        <component numericId="93" componentId="meshing_contact_gear_data_set" nameEn="Meshing contact gear data of a point list" nameDe="Eingriffsbezogene Zahnraddaten einer Punkteliste" databaseId="1615"/>
+        <component numericId="94" componentId="meshing_contact_stage_data_set" nameEn="Meshing contact stage data of a point list" nameDe="Eingriffsbezogene Stufendaten einer Punkteliste" databaseId="1616"/>
+        <component numericId="98" componentId="notch_effect_shaft_hub_connection" nameEn="Notch effect of shaft-hub-connection" nameDe="Kerbwirkung der Welle-Nabe-Verbindung" databaseId="1617"/>
+        <component numericId="30" componentId="planet_carrier" nameEn="Planetary carrier" nameDe="Planetenträger" databaseId="1618"/>
+        <component numericId="29" componentId="planetary_stage" nameEn="Planetary stage" nameDe="Planetenstufe" databaseId="1619"/>
+        <component numericId="89" componentId="point_list" nameEn="Point list" nameDe="Punkteliste" databaseId="1620"/>
+        <component numericId="40" componentId="profile_crowning" nameEn="Profile crowning" nameDe="Profil-Balligkeit" databaseId="1621"/>
+        <component numericId="59" componentId="profile_deviation" nameEn="Profile deviation" nameDe="Profil-Abweichung" databaseId="1622"/>
+        <component numericId="39" componentId="profile_slope" nameEn="Profile slope modification" nameDe="Profil-Winkelmodifikation" databaseId="1623"/>
+        <component numericId="61" componentId="profile_twist" nameEn="Profile twist" nameDe="Profil-Schränkung" databaseId="1624"/>
+        <component numericId="16" componentId="rack_shaped_tool" nameEn="Rack-shaped tool" nameDe="Zahnstangenförmiges Werkzeug" databaseId="1625"/>
+        <component numericId="109" componentId="radial_plain_bearing_groove" nameEn="Plain bearing groove" nameDe="Gleitlagernut" databaseId="1664"/>
+        <component numericId="107" componentId="radial_plain_bearing_hole" nameEn="Plain bearing hole" nameDe="Gleitlagerbohrung" databaseId="1662"/>
+        <component numericId="106" componentId="radial_plain_bearing_profile" nameEn="Plain bearing profile" nameDe="Gleitlagerprofil" databaseId="1661"/>
+        <component numericId="111" componentId="radial_plain_bearing_profile_data_set" nameEn="Plain bearing profiel data set" nameDe="Gleitlager-Profildatensatz" databaseId="1666"/>
+        <component numericId="105" componentId="radial_plain_bearing_shell" nameEn="Plain bearing shell" nameDe="Gleitlagerschale" databaseId="1660"/>
+        <component numericId="108" componentId="radial_plain_bearing_slot" nameEn="Plain bearing slot" nameDe="Hydrostatische Tasche" databaseId="1663"/>
+        <component numericId="70" componentId="rectangular_groove" nameEn="Rectangular groove" nameDe="Rechtecknut" databaseId="1626"/>
+        <component numericId="35" componentId="reduction_point" nameEn="Reduction point" nameDe="Reduktionspunkt" databaseId="1627"/>
+        <component numericId="33" componentId="ring_gear" nameEn="Ring gear" nameDe="Hohlrad" databaseId="1628"/>
+        <component numericId="17" componentId="rolling_bearing_row" nameEn="Rolling bearing row" nameDe="Wälzlagerreihe" databaseId="1629"/>
+        <component numericId="18" componentId="rolling_bearing_with_catalog_geometry" nameEn="Rolling bearing with catalog data" nameDe="Wälzlager mit Katalogdaten" databaseId="1630"/>
+        <component numericId="19" componentId="rolling_bearing_with_detailed_geometry" nameEn="Rolling bearing with detailed geometry" nameDe="Wälzlager mit Innengeometrie" databaseId="1631"/>
+        <component numericId="20" componentId="rolling_element" nameEn="Rolling element" nameDe="Wälzkörper" databaseId="1632"/>
+        <component numericId="66" componentId="rolling_element_contact" nameEn="Rolling element contact" nameDe="Wälzkörperkontakt" databaseId="1633"/>
+        <component numericId="38" componentId="root_relief" nameEn="Root relief" nameDe="Fußrücknahme" databaseId="1634"/>
+        <component numericId="69" componentId="round_groove" nameEn="Round groove" nameDe="Rundkerbe" databaseId="1635"/>
+        <component numericId="22" componentId="shaft" nameEn="Shaft" nameDe="Welle" databaseId="1636"/>
+        <component numericId="23" componentId="shaft_section" nameEn="Shaft section" nameDe="Wellenabschnitt" databaseId="1637"/>
+        <component numericId="67" componentId="shaft_shoulder" nameEn="Shaft shoulder" nameDe="Wellenabsatz" databaseId="1638"/>
+        <component numericId="68" componentId="shaft_shoulder_with_undercut" nameEn="Shaft shoulder with undercut" nameDe="Wellenabsatz mit Freistich" databaseId="1639"/>
+        <component numericId="31" componentId="side_plate" nameEn="Side plate" nameDe="Wange" databaseId="1640"/>
+        <component numericId="114" componentId="sleeve" nameEn="Sleeve" nameDe="Hülse" databaseId="1669"/>
+        <component numericId="24" componentId="slide_bearing" nameEn="Slide bearing" nameDe="Gleitlager" databaseId="1641"/>
+        <component numericId="88" componentId="sn_curve" nameEn="S/N Curve" nameDe="Wöhlerlinie" databaseId="1642"/>
+        <component numericId="115" componentId="surface_contact" nameEn="Surface contact" nameDe="Oberflächenkontakt" databaseId="1670"/>
+        <component numericId="26" componentId="switchable_coupling" nameEn="Switchable coupling" nameDe="Schaltbare Kupplung" databaseId="1643"/>
+        <component numericId="97" componentId="tapered_interference_fit" nameEn="Tapered interference fit" nameDe="Kegeliger Pressverband" databaseId="1644"/>
+        <component numericId="37" componentId="tip_relief" nameEn="Tip relief" nameDe="Kopfrücknahme" databaseId="1645"/>
+        <component numericId="44" componentId="topographical_modification" nameEn="Topographical flank modification" nameDe="Topografische Flankenmodifikation" databaseId="1646"/>
+        <component numericId="72" componentId="transverse_bore" nameEn="Transverse bore" nameDe="Querbohrung" databaseId="1647"/>
+        <component numericId="63" componentId="triangular_root_relief" nameEn="Triangular root relief" nameDe="Dreieckförmige Fußrücknahme" databaseId="1648"/>
+        <component numericId="62" componentId="triangular_tip_relief" nameEn="Triangular tip relief" nameDe="Dreieckförmige Kopfrücknahme" databaseId="1649"/>
+        <component numericId="71" componentId="v_notch" nameEn="V-notch" nameDe="Spitzkerbe" databaseId="1650"/>
+        <component numericId="57" componentId="worm_gear" nameEn="Worm gear" nameDe="Schnecke" databaseId="1651"/>
+        <component numericId="81" componentId="worm_gear_flank" nameEn="Flank of worm gear or worm wheel" nameDe="Zahnflanke einer Schnecke oder eines Schneckenrades" databaseId="1652"/>
+        <component numericId="85" componentId="worm_gear_manufacturing_settings" nameEn="Worm gear and worm wheel manufacturing settings" nameDe="Einstellungen für die Herstellung von Schnecken und Schneckenrädern" databaseId="1653"/>
+        <component numericId="73" componentId="worm_grinding_disc_tool" nameEn="Worm grinding disc" nameDe="Schneckenschleifscheibe" databaseId="1654"/>
+        <component numericId="56" componentId="worm_stage" nameEn="Worm stage" nameDe="Schneckenstufe" databaseId="1655"/>
+        <component numericId="78" componentId="worm_stage_gear_data" nameEn="Worm stage gear data" nameDe="Radbezogene Eingriffsdaten (Schneckenstufe)" databaseId="1656"/>
+        <component numericId="58" componentId="worm_wheel" nameEn="Worm wheel" nameDe="Schneckenrad" databaseId="1657"/>
+        <component numericId="74" componentId="worm_wheel_hob_tool" nameEn="Worm wheel hob" nameDe="Schneckenradfräser" databaseId="1658"/>
+        <component numericId="27" componentId="zero_degree_grinding_disk_tool" nameEn="0° grinding disk tool" nameDe="0° Schleifscheibe" databaseId="1659"/>
     </components>
     <attributes>
         <attribute numericId="5406" attributeId="acceleration_factor_according_fva_341" valueType="1" unit="4" nameEn="Acceleration factor according to FVA 341" nameDe="Beschleunigungsfaktor nach FVA 341" rangeMin="0.0" rangeMinIntervalOpen="false" rangeMaxIntervalOpen="true" databaseId="27311"/>

--- a/api/src/main/resources/info/rexs/xsd/rexs-schema.xsd
+++ b/api/src/main/resources/info/rexs/xsd/rexs-schema.xsd
@@ -122,6 +122,7 @@
 
 	<xsd:element name="component">
 		<xsd:complexType>
+			<xsd:attribute name="numericId" type="xsd:int" use="required"/>
 			<xsd:attribute name="componentId" type="xsd:string" use="required"/>
 			<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
 			<xsd:attribute name="nameDe" type="xsd:string" use="required"/>


### PR DESCRIPTION
This pull request resolves #166.
The numeric ID for components is added in the XSD and all existing XML schema files have been updated.