### PR TITLE
Simplification of JAXB classes by removing trivial classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renaming default branch from "master" to "main"
 - Changed class types on data classes from `BigInteger` and `BigDecimal` to `int` and `double`
 - Added numericId to components in schema files
-
+- Simplified the XSDs for the REXS schema and changelog XMLs
 
 ## [0.9.0] - 2024-10-23
 

--- a/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
@@ -31,7 +31,6 @@ import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.schema.jaxb.AllowedCombination;
 import info.rexs.schema.jaxb.AllowedCombinationRole;
-import info.rexs.schema.jaxb.AllowedCombinations;
 import info.rexs.schema.jaxb.Attribute;
 import info.rexs.schema.jaxb.Component;
 import info.rexs.schema.jaxb.ComponentAttributeMapping;
@@ -107,11 +106,10 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	private void generateRelationsWithAllowedCombinations(RexsVersion version, RexsSchema rexsModel) {
 		Map<RexsRelationType, List<List<AllowedCombinationRole>>> relationsToAllowedCombinationsMapofVersion = relationsToAllowedCombinationsMap.computeIfAbsent(version, k -> new HashMap<>());
 		if (rexsModel.getRelations() != null) {
-			for (Relation relation : rexsModel.getRelations().getRelation()) {
+			for (Relation relation : rexsModel.getRelations()) {
 				RexsRelationType relationType = RexsRelationType.findByKey(relation.getRelationId());
 				List<List<AllowedCombinationRole>> listOfCombinations = relationsToAllowedCombinationsMapofVersion.computeIfAbsent(relationType, k -> new ArrayList<>());
-				AllowedCombinations combinations = relation.getAllowedCombinations();
-				for (AllowedCombination combination : combinations.getAllowedCombination())
+				for (AllowedCombination combination : relation.getAllowedCombinations())
 					listOfCombinations.add(combination.getAllowedCombinationRole());
 			}
 		}
@@ -119,7 +117,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 
 	private void generateComponentMap(RexsVersion version, RexsSchema rexsModel) {
 		Map<String, RexsComponentType> mapOfVersion = componentMap.computeIfAbsent(version, k -> new HashMap<>());
-		for (Component component : rexsModel.getComponents().getComponent()) {
+		for (Component component : rexsModel.getComponents()) {
 			RexsComponentType componentType = RexsComponentType.findById(component.getComponentId());
 			mapOfVersion.put(component.getComponentId(), componentType);
 		}
@@ -133,7 +131,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	 */
 	private void generateAttributeMap(RexsVersion version, RexsSchema rexsModel) {
 		Map<String, Attribute> mapofVersion = attributeMap.computeIfAbsent(version, k -> new HashMap<>());
-		for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+		for (Attribute attribute : rexsModel.getAttributes()) {
 			mapofVersion.put(attribute.getAttributeId(), attribute);
 		}
 	}
@@ -148,12 +146,12 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsValueType> mapofVersion = attributeTypes.computeIfAbsent(version, k -> new HashMap<>());
 		Map<Integer, String> valueTypeMap = new HashMap<>();
 		if (rexsModel.getValueTypes() != null) {
-			for (ValueType valueType : rexsModel.getValueTypes().getValueType()) {
+			for (ValueType valueType : rexsModel.getValueTypes()) {
 				valueTypeMap.put(valueType.getId(), valueType.getName());
 			}
 		}
 		if (rexsModel.getAttributes() != null) {
-			for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+			for (Attribute attribute : rexsModel.getAttributes()) {
 				mapofVersion.put(attribute.getAttributeId(), RexsValueType.findByKey(valueTypeMap.get(attribute.getValueType())));
 			}
 		}
@@ -163,7 +161,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsUnitId> mapofVersion = attributeUnits.computeIfAbsent(version, k -> new HashMap<>());
 		Map<Integer, String> unitMap = new HashMap<>();
 		if (rexsModel.getUnits() != null) {
-			for (Unit unit : rexsModel.getUnits().getUnit()) {
+			for (Unit unit : rexsModel.getUnits()) {
 				if (RexsStandardUnitIds.degree.getId().equals(unit.getName()))
 					unitMap.put(unit.getId(), RexsStandardUnitIds.deg.getId());
 				else
@@ -171,7 +169,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 			}
 		}
 		if (rexsModel.getAttributes() != null) {
-			for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+			for (Attribute attribute : rexsModel.getAttributes()) {
 				String unit = unitMap.get(attribute.getUnit());
 				mapofVersion.put(attribute.getAttributeId(), RexsUnitId.findById(unit));
 			}
@@ -245,7 +243,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	@Override
 	public String getNameForEnumValue(String attributeId, RexsVersion version, String value) {
 		Attribute attribute = attributeMap.get(version).get(attributeId);
-		for (EnumValue enumValue : attribute.getEnumValues().getEnumValue()) {
+		for (EnumValue enumValue : attribute.getEnumValues()) {
 			if (enumValue.getValue().equals(value)) {
 				if (getLanguageDefaultLocale().equals("de"))
 					return enumValue.getNameDe();
@@ -267,7 +265,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, List<RexsComponentType>> attributeToComponentMapofVersion = attributeToComponentMap.computeIfAbsent(version, k -> new HashMap<>());
 		Map<RexsComponentType, List<String>> componentToAttributeMapofVersion = componentToAttributesMap.computeIfAbsent(version, k -> new HashMap<>());
 		if (rexsModel.getComponentAttributeMappings() != null) {
-			for (ComponentAttributeMapping mapping : rexsModel.getComponentAttributeMappings().getComponentAttributeMapping()) {
+			for (ComponentAttributeMapping mapping : rexsModel.getComponentAttributeMappings()) {
 				RexsComponentType componentType = RexsComponentType.findById(mapping.getComponentId());
 				String attributeId = mapping.getAttributeId();
 

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
@@ -61,16 +61,16 @@ public class ModelChangelogUpgrader {
 
 	public RexsModel applyChangelog() throws RexsUpgradeException {
 		if (changelog.getComponentChanges() != null)
-			for (ComponentChange change : changelog.getComponentChanges().getComponentChange()) {
+			for (ComponentChange change : changelog.getComponentChanges()) {
 				if (change.getType() == ChangeType.DELETE)
 					deleteComponentsByType(newModel, change.getId());
 
 				if (change.getType() == ChangeType.EDIT)
-					editComponentsByType(change.getId(), change.getChangedValues().getChangedValue());
+					editComponentsByType(change.getId(), change.getChangedValues());
 			}
 
 		if (changelog.getMappingChanges() != null)
-			for (MappingChange change : changelog.getMappingChanges().getMappingChange()) {
+			for (MappingChange change : changelog.getMappingChanges()) {
 				if (change.getType() == ChangeType.DELETE) {
 					if (strictMode) {
 						deleteAttributesByComponentTypeAndAttributeId(newModel, change.getComponentId(), change.getAttributeId());
@@ -81,9 +81,9 @@ public class ModelChangelogUpgrader {
 			}
 
 		if (changelog.getAttributeChanges() != null)
-			for (AttributeChange change : changelog.getAttributeChanges().getAttributeChange()) {
+			for (AttributeChange change : changelog.getAttributeChanges()) {
 				if (change.getType() == ChangeType.EDIT)
-					editAttributesById(change.getId(), change.getChangedValues().getChangedValue());
+					editAttributesById(change.getId(), change.getChangedValues());
 			}
 
 		return newModel;
@@ -233,20 +233,16 @@ public class ModelChangelogUpgrader {
 
 
 	private void changeEnumValue(RexsAttribute attribute, ChangedValue changedValue) {
-		for (EnumValueChange enumChange: changedValue.getEnumValueChanges().getEnumValueChange()) {
+		for (EnumValueChange enumChange: changedValue.getEnumValueChanges()) {
 			switch (enumChange.getType()) {
-			case ADD: {
+			case ADD, DELETE: {
 				// Do nothing. Change must be handled by custom upgrade.
 				break;
 			}
-			case DELETE: {
-				// Do nothing. Change must be handled by custom upgrade.
-				break;
-			}
-			case EDIT: {
+				case EDIT: {
 				String attrValue = attribute.getStringValue();
 				if (attrValue.equals(enumChange.getValue())) {
-					ChangedValue changedEnumValue = enumChange.getChangedValues().getChangedValue().get(0);
+					ChangedValue changedEnumValue = enumChange.getChangedValues().get(0);
 					String newName = changedEnumValue.getNewValue();
 					attribute.setStringValue(newName);
 				}
@@ -262,7 +258,7 @@ public class ModelChangelogUpgrader {
 			RexsComponent component,
 			RexsAttribute attribute,
 			RexsValueType oldType,
-			RexsValueType newType) throws RexsUpgradeException {
+			RexsValueType newType) {
 
 		String rawValue = attribute.getRawValue().getValueString();
 		switch(newType) {

--- a/api/src/main/resources/info/rexs/xsd/rexs-changelog.xsd
+++ b/api/src/main/resources/info/rexs/xsd/rexs-changelog.xsd
@@ -1,150 +1,80 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" elementFormDefault="qualified" >
+			xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" elementFormDefault="qualified">
 
 	<xsd:element name="rexsChangelog">
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element ref="componentChanges" minOccurs="0"/>
-				<xsd:element ref="attributeChanges" minOccurs="0"/>
-				<xsd:element ref="mappingChanges"   minOccurs="0"/>
-				<xsd:element ref="relationChanges"  minOccurs="0"/>
+				<xsd:element name="componentChanges" type="componentChange" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="attributeChanges" type="attributeChange" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="mappingChanges" type="mappingChange" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="relationChanges" type="relationChange" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
 			<xsd:attribute name="fromVersion" type="xsd:string" use="required"/>
-			<xsd:attribute name="toVersion"   type="xsd:string" use="required"/>
+			<xsd:attribute name="toVersion" type="xsd:string" use="required"/>
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:element name="componentChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="componentChange" minOccurs="0" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="componentChange">
+		<xsd:sequence>
+			<xsd:element name="changedValues" type="changedValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="componentChange">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="type" type="changeType" use="required"/>
-			<xsd:attribute name="id"   type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="attributeChange">
+		<xsd:sequence>
+			<xsd:element name="changedValues" type="changedValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+		<xsd:attribute name="numericId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="attributeChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="attributeChange" minOccurs="0" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="mappingChange">
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="componentId" type="xsd:string" use="required"/>
+		<xsd:attribute name="attributeId" type="xsd:string" use="required"/>
+		<xsd:attribute name="attributeNumericId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="attributeChange">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="type"      type="changeType" use="required"/>
-			<xsd:attribute name="id"        type="xsd:string" use="required"/>
-			<xsd:attribute name="numericId" type="xsd:int"    use="required"/>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="relationChange">
+		<xsd:sequence>
+			<xsd:element name="changedValues" type="changedValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="id" type="xsd:string" use="required"/>
+		<xsd:attribute name="numericId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="mappingChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="mappingChange" minOccurs="0" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="changedValue">
+		<xsd:sequence>
+			<xsd:element name="enumValueChanges" type="enumValueChange" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="roleChanges" type="roleChange" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="key" type="xsd:string" use="required"/>
+		<xsd:attribute name="lang" type="xsd:string"/>
+		<xsd:attribute name="oldValue" type="xsd:string"/>
+		<xsd:attribute name="newValue" type="xsd:string"/>
+	</xsd:complexType>
 
-	<xsd:element name="mappingChange">
-		<xsd:complexType>
-			<xsd:attribute name="type"               type="changeType" use="required"/>
-			<xsd:attribute name="componentId"        type="xsd:string" use="required"/>
-			<xsd:attribute name="attributeId"        type="xsd:string" use="required"/>
-			<xsd:attribute name="attributeNumericId" type="xsd:int"    use="required"/>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="enumValueChange">
+		<xsd:sequence>
+			<xsd:element name="changedValues" type="changedValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="value" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="relationChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="relationChange" minOccurs="0" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="relationChange">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="type"      type="changeType" use="required"/>
-			<xsd:attribute name="id"        type="xsd:string" use="required"/>
-			<xsd:attribute name="numericId" type="xsd:int"    use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="changedValues">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValue" minOccurs="0" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="changedValue">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="enumValueChanges" minOccurs="0"/>
-				<xsd:element ref="roleChanges" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="key"      type="xsd:string" use="required"/>
-			<xsd:attribute name="lang"     type="xsd:string"/>
-			<xsd:attribute name="oldValue" type="xsd:string"/>
-			<xsd:attribute name="newValue" type="xsd:string"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="enumValueChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="enumValueChange" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="enumValueChange">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="type"  type="changeType" use="required"/>
-			<xsd:attribute name="value" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="roleChanges">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="roleChange" maxOccurs="unbounded"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="roleChange">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="changedValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="type"  type="changeType" use="required"/>
-			<xsd:attribute name="roleId" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="roleChange">
+		<xsd:sequence>
+			<xsd:element name="changedValues" type="changedValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="type" type="changeType" use="required"/>
+		<xsd:attribute name="roleId" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
 	<xsd:simpleType name="changeType">
 		<xsd:restriction base="xsd:string">

--- a/api/src/main/resources/info/rexs/xsd/rexs-schema.xsd
+++ b/api/src/main/resources/info/rexs/xsd/rexs-schema.xsd
@@ -15,17 +15,17 @@
   the License.
 -->
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" elementFormDefault="qualified" >
+			xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" jaxb:version="3.0" elementFormDefault="qualified">
 
 	<xsd:element name="rexsSchema">
 		<xsd:complexType>
 			<xsd:sequence>
-				<xsd:element ref="units" minOccurs="0"/>
-				<xsd:element ref="valueTypes" minOccurs="0"/>
-				<xsd:element ref="components" minOccurs="0"/>
-				<xsd:element ref="attributes" minOccurs="0"/>
-				<xsd:element ref="componentAttributeMappings" minOccurs="0"/>
-				<xsd:element ref="relations" minOccurs="0"/>
+				<xsd:element name="units" type="unit" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="valueTypes" type="valueType" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="components" type="component" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="attributes" type="attribute" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="componentAttributeMappings" type="componentAttributeMapping" minOccurs="0" maxOccurs="unbounded"/>
+				<xsd:element name="relations" type="relation" minOccurs="0" maxOccurs="unbounded"/>
 			</xsd:sequence>
 			<xsd:attribute name="version" type="xsd:string" use="required"/>
 			<xsd:attribute name="status" type="versionStatusType" use="required"/>
@@ -34,164 +34,74 @@
 		</xsd:complexType>
 	</xsd:element>
 
-	<xsd:element name="units">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="unit" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="unit">
+		<xsd:attribute name="id" type="xsd:int" use="required"/>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="valueTypes">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="valueType" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="valueType">
+		<xsd:attribute name="id" type="xsd:int" use="required"/>
+		<xsd:attribute name="name" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="components">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="component" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="component">
+		<xsd:attribute name="numericId" type="xsd:int" use="required"/>
+		<xsd:attribute name="componentId" type="xsd:string" use="required"/>
+		<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
+		<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
+		<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="attributes">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="attribute" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="attribute">
+		<xsd:sequence>
+			<xsd:element name="enumValues" type="enumValue" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="numericId" type="xsd:int" use="required"/>
+		<xsd:attribute name="attributeId" type="xsd:string" use="required"/>
+		<xsd:attribute name="valueType" type="xsd:int" use="required"/>
+		<xsd:attribute name="unit" type="xsd:int" use="required"/>
+		<xsd:attribute name="symbol" type="xsd:string"/>
+		<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
+		<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
+		<xsd:attribute name="rangeMin" type="xsd:double"/>
+		<xsd:attribute name="rangeMinIntervalOpen" type="xsd:boolean"/>
+		<xsd:attribute name="rangeMax" type="xsd:double"/>
+		<xsd:attribute name="rangeMaxIntervalOpen" type="xsd:boolean"/>
+		<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="enumValues">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="enumValue" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="enumValue">
+		<xsd:attribute name="value" type="xsd:string" use="required"/>
+		<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
+		<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="componentAttributeMappings">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="componentAttributeMapping" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="componentAttributeMapping">
+		<xsd:attribute name="componentId" type="xsd:string" use="required"/>
+		<xsd:attribute name="attributeId" type="xsd:string" use="required"/>
+		<xsd:attribute name="attributeNumericId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="relations">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="relation" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="relation">
+		<xsd:sequence>
+			<xsd:element name="roles" type="role" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element name="allowedCombinations" type="allowedCombination" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="numericId" type="xsd:int" use="required"/>
+		<xsd:attribute name="relationId" type="xsd:string" use="required"/>
+		<xsd:attribute name="orderRequired" type="xsd:boolean" use="required"/>
+		<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="roles">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="role" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="role">
+		<xsd:attribute name="roleId" type="xsd:string" use="required"/>
+	</xsd:complexType>
 
-	<xsd:element name="allowedCombinations">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="allowedCombination" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="unit">
-		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:int" use="required"/>
-			<xsd:attribute name="name" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="valueType">
-		<xsd:complexType>
-			<xsd:attribute name="id" type="xsd:int" use="required"/>
-			<xsd:attribute name="name" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="component">
-		<xsd:complexType>
-			<xsd:attribute name="numericId" type="xsd:int" use="required"/>
-			<xsd:attribute name="componentId" type="xsd:string" use="required"/>
-			<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
-			<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
-			<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="attribute">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="enumValues" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="numericId" type="xsd:int" use="required"/>
-			<xsd:attribute name="attributeId" type="xsd:string" use="required"/>
-			<xsd:attribute name="valueType" type="xsd:int" use="required"/>
-			<xsd:attribute name="unit" type="xsd:int" use="required"/>
-			<xsd:attribute name="symbol" type="xsd:string"/>
-			<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
-			<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
-			<xsd:attribute name="rangeMin" type="xsd:double"/>
-			<xsd:attribute name="rangeMinIntervalOpen" type="xsd:boolean"/>
-			<xsd:attribute name="rangeMax" type="xsd:double"/>
-			<xsd:attribute name="rangeMaxIntervalOpen" type="xsd:boolean"/>
-			<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="enumValue">
-		<xsd:complexType>
-			<xsd:attribute name="value" type="xsd:string" use="required"/>
-			<xsd:attribute name="nameEn" type="xsd:string" use="required"/>
-			<xsd:attribute name="nameDe" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="componentAttributeMapping">
-		<xsd:complexType>
-			<xsd:attribute name="componentId" type="xsd:string" use="required"/>
-			<xsd:attribute name="attributeId" type="xsd:string" use="required"/>
-			<xsd:attribute name="attributeNumericId" type="xsd:int" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="relation">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="roles" minOccurs="0"/>
-				<xsd:element ref="allowedCombinations" minOccurs="0"/>
-			</xsd:sequence>
-			<xsd:attribute name="numericId" type="xsd:int" use="required"/>
-			<xsd:attribute name="relationId" type="xsd:string" use="required"/>
-			<xsd:attribute name="orderRequired" type="xsd:boolean" use="required"/>
-			<xsd:attribute name="databaseId" type="xsd:int" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="role">
-		<xsd:complexType>
-			<xsd:attribute name="roleId" type="xsd:string" use="required"/>
-		</xsd:complexType>
-	</xsd:element>
-
-	<xsd:element name="allowedCombination">
-		<xsd:complexType>
-			<xsd:sequence>
-				<xsd:element ref="allowedCombinationRole" maxOccurs="unbounded" minOccurs="0"/>
-			</xsd:sequence>
-		</xsd:complexType>
-	</xsd:element>
+	<xsd:complexType name="allowedCombination">
+		<xsd:sequence>
+			<xsd:element ref="allowedCombinationRole" maxOccurs="unbounded" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
 
 	<xsd:element name="allowedCombinationRole">
 		<xsd:complexType>


### PR DESCRIPTION
The XSD files `xsd-schema.xsd` and `xsd-changelog.xsd` have been refactored and simplified. The changes will not induce any differences in the actual XML files. However, the generated JAXB Java classes will be simpler in handling and trivial classes will be removed.

Example:

Earlier, the `RexsSchema` class had one field `Relations relations`, with the `Relations` class having only one single field `List<Relation> relation`. In order to access the list of relations, two steps had to be taken: `List<Relation> relations = rexsSchema.getRelations().getRelation;`

In the new approach, `RexsSchema` holds a field `List<Relation> relations`, so the list can be accessed directly by `List<Relation> relations = rexsSchema.getRelations();`

These changes have been applied to `RexsSchemaRegistry` so that from the outside, the API behaves the same way as before.