### PR TITLE
Simplify JAXB classes by using element wrappers instead of wrapper classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ???
+- JAXB classes are now using element wrappers instead of wrapper classes
 
 
 ## [0.10.0] - 2024-11-05
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Using JAXB to generate data classes
-- JAXB classes are now using element wrappers instead of wrapper classes
 - Renaming default branch from "master" to "main"
 - Changed class types on data classes from `BigInteger` and `BigDecimal` to `int` and `double`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Using JAXB to generate data classes
+- JAXB classes are now using element wrappers instead of wrapper classes
 - Renaming default branch from "master" to "main"
 - Changed class types on data classes from `BigInteger` and `BigDecimal` to `int` and `double`
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,172 +15,187 @@
   the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>io.github.fva-net</groupId>
-		<artifactId>rexs-api-java-project</artifactId>
-		<version>0.11.0-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
-	</parent>
+    <parent>
+        <groupId>io.github.fva-net</groupId>
+        <artifactId>rexs-api-java-project</artifactId>
+        <version>0.11.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-	<artifactId>rexs-api-java</artifactId>
+    <artifactId>rexs-api-java</artifactId>
 
-	<name>REXS-API-Java :: API</name>
+    <name>REXS-API-Java :: API</name>
 
-	<dependencies>
+    <dependencies>
 
-		<!-- JAXB API only -->
-		<dependency>
-			<groupId>jakarta.xml.bind</groupId>
-			<artifactId>jakarta.xml.bind-api</artifactId>
-		</dependency>
+        <!-- JAXB API only -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
 
-		<!-- JAXB implementation -->
-		<dependency>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
-		</dependency>
+        <!-- JAXB implementation -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jaxb-xew-plugin</groupId>
+            <artifactId>jaxb-xew-plugin</artifactId>
+            <version>2.1</version>
+        </dependency>
 
-		<!-- Jackson for JSON -->
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-databind</artifactId>
-		</dependency>
+        <!-- Jackson for JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
 
-		<!-- Unit tesing -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
+        <!-- Unit tesing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
-	</dependencies>
+    </dependencies>
 
-	<build>
-		<resources>
-			<resource>
-				<directory>src/main/resources/</directory>
-				<excludes>
-					<exclude>**/*.properties</exclude>
-					<exclude>**/*.yml</exclude>
-				</excludes>
-				<filtering>false</filtering>
-			</resource>
-			<resource>
-				<directory>src/main/resources/</directory>
-				<includes>
-					<include>**/*.properties</include>
-					<include>**/*.yml</include>
-				</includes>
-				<filtering>true</filtering>
-			</resource>
-		</resources>
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <excludes>
+                    <exclude>**/*.properties</exclude>
+                    <exclude>**/*.yml</exclude>
+                </excludes>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                    <include>**/*.yml</include>
+                </includes>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
 
-		<plugins>
+        <plugins>
 
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>add-source</id>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>add-source</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${project.build.directory}/generated-sources/jaxb/rexs-schema</source>
-								<source>${project.build.directory}/generated-sources/jaxb/rexs-file</source>
-								<source>${project.build.directory}/generated-sources/jaxb/rexs-changelog</source>
-							</sources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/jaxb/rexs-schema</source>
+                                <source>${project.build.directory}/generated-sources/jaxb/rexs-file</source>
+                                <source>${project.build.directory}/generated-sources/jaxb/rexs-changelog</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>jaxb2-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>xjc-rexs-schema</id>
-						<goals>
-							<goal>xjc</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-schema.xsd</source>
-							</sources>
-							<packageName>info.rexs.schema.jaxb</packageName>
-							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-schema</outputDirectory>
-						</configuration>
-					</execution>
-					<execution>
-						<id>xjc-rexs-file</id>
-						<goals>
-							<goal>xjc</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-file.xsd</source>
-							</sources>
-							<packageName>info.rexs.model.jaxb</packageName>
-							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-file</outputDirectory>
-						</configuration>
-					</execution>
-					<execution>
-						<id>xjc-rexs-changelog</id>
-						<goals>
-							<goal>xjc</goal>
-						</goals>
-						<configuration>
-							<sources>
-								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-changelog.xsd</source>
-							</sources>
-							<packageName>info.rexs.upgrade.upgraders.changelog.jaxb</packageName>
-							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-changelog</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>xjc-rexs-schema</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-schema.xsd</source>
+                            </sources>
+                            <packageName>info.rexs.schema.jaxb</packageName>
+                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-schema</outputDirectory>
+                            <arguments>
+                                <argument>-Xxew</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>xjc-rexs-file</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-file.xsd</source>
+                            </sources>
+                            <packageName>info.rexs.model.jaxb</packageName>
+                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-file</outputDirectory>
+                            <arguments>
+                                <argument>-Xxew</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>xjc-rexs-changelog</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-changelog.xsd</source>
+                            </sources>
+                            <packageName>info.rexs.upgrade.upgraders.changelog.jaxb</packageName>
+                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-changelog</outputDirectory>
+                            <arguments>
+                                <argument>-Xxew</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-		</plugins>
-	</build>
+        </plugins>
+    </build>
 
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,36 +14,36 @@
   License for the specific language governing permissions and limitations under
   the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>io.github.fva-net</groupId>
-        <artifactId>rexs-api-java-project</artifactId>
-        <version>0.11.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
+	<parent>
+		<groupId>io.github.fva-net</groupId>
+		<artifactId>rexs-api-java-project</artifactId>
+		<version>0.11.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
 
-    <artifactId>rexs-api-java</artifactId>
+	<artifactId>rexs-api-java</artifactId>
 
-    <name>REXS-API-Java :: API</name>
+	<name>REXS-API-Java :: API</name>
 
-    <dependencies>
+	<dependencies>
 
-        <!-- JAXB API only -->
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
+		<!-- JAXB API only -->
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+		</dependency>
 
-        <!-- JAXB implementation -->
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-        </dependency>
+		<!-- JAXB implementation -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.github.jaxb-xew-plugin</groupId>
             <artifactId>jaxb-xew-plugin</artifactId>
@@ -51,151 +51,150 @@
         </dependency>
 
         <!-- Jackson for JSON -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 
-        <!-- Unit tesing -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
+		<!-- Unit tesing -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 
-    </dependencies>
+	</dependencies>
 
-    <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources/</directory>
-                <excludes>
-                    <exclude>**/*.properties</exclude>
-                    <exclude>**/*.yml</exclude>
-                </excludes>
-                <filtering>false</filtering>
-            </resource>
-            <resource>
-                <directory>src/main/resources/</directory>
-                <includes>
-                    <include>**/*.properties</include>
-                    <include>**/*.yml</include>
-                </includes>
-                <filtering>true</filtering>
-            </resource>
-        </resources>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<excludes>
+					<exclude>**/*.properties</exclude>
+					<exclude>**/*.yml</exclude>
+				</excludes>
+				<filtering>false</filtering>
+			</resource>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<includes>
+					<include>**/*.properties</include>
+					<include>**/*.yml</include>
+				</includes>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 
-        <plugins>
+		<plugins>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${project.build.directory}/generated-sources/jaxb/rexs-schema</source>
-                                <source>${project.build.directory}/generated-sources/jaxb/rexs-file</source>
-                                <source>${project.build.directory}/generated-sources/jaxb/rexs-changelog</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-sources/jaxb/rexs-schema</source>
+								<source>${project.build.directory}/generated-sources/jaxb/rexs-file</source>
+								<source>${project.build.directory}/generated-sources/jaxb/rexs-changelog</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>xjc-rexs-schema</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-schema.xsd</source>
-                            </sources>
-                            <packageName>info.rexs.schema.jaxb</packageName>
-                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-schema</outputDirectory>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>jaxb2-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>xjc-rexs-schema</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-schema.xsd</source>
+							</sources>
+							<packageName>info.rexs.schema.jaxb</packageName>
+							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-schema</outputDirectory>
                             <arguments>
                                 <argument>-Xxew</argument>
                             </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>xjc-rexs-file</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-file.xsd</source>
-                            </sources>
-                            <packageName>info.rexs.model.jaxb</packageName>
-                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-file</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>xjc-rexs-file</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-file.xsd</source>
+							</sources>
+							<packageName>info.rexs.model.jaxb</packageName>
+							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-file</outputDirectory>
                             <arguments>
                                 <argument>-Xxew</argument>
                             </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>xjc-rexs-changelog</id>
-                        <goals>
-                            <goal>xjc</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${basedir}/src/main/resources/info/rexs/xsd/rexs-changelog.xsd</source>
-                            </sources>
-                            <packageName>info.rexs.upgrade.upgraders.changelog.jaxb</packageName>
-                            <outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-changelog</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>xjc-rexs-changelog</id>
+						<goals>
+							<goal>xjc</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${basedir}/src/main/resources/info/rexs/xsd/rexs-changelog.xsd</source>
+							</sources>
+							<packageName>info.rexs.upgrade.upgraders.changelog.jaxb</packageName>
+							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-changelog</outputDirectory>
                             <arguments>
                                 <argument>-Xxew</argument>
                             </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,13 +44,15 @@
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
-        <dependency>
-            <groupId>com.github.jaxb-xew-plugin</groupId>
-            <artifactId>jaxb-xew-plugin</artifactId>
-            <version>2.1</version>
-        </dependency>
 
-        <!-- Jackson for JSON -->
+		<!-- JAXB @XmlElementWrapper Plugin (see https://github.com/dmak/jaxb-xew-plugin) -->
+		<dependency>
+			<groupId>com.github.jaxb-xew-plugin</groupId>
+			<artifactId>jaxb-xew-plugin</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Jackson for JSON -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
@@ -128,9 +130,9 @@
 							</sources>
 							<packageName>info.rexs.schema.jaxb</packageName>
 							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-schema</outputDirectory>
-                            <arguments>
-                                <argument>-Xxew</argument>
-                            </arguments>
+							<arguments>
+								<argument>-Xxew</argument>
+							</arguments>
 						</configuration>
 					</execution>
 					<execution>
@@ -144,9 +146,9 @@
 							</sources>
 							<packageName>info.rexs.model.jaxb</packageName>
 							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-file</outputDirectory>
-                            <arguments>
-                                <argument>-Xxew</argument>
-                            </arguments>
+							<arguments>
+								<argument>-Xxew</argument>
+							</arguments>
 						</configuration>
 					</execution>
 					<execution>
@@ -160,9 +162,9 @@
 							</sources>
 							<packageName>info.rexs.upgrade.upgraders.changelog.jaxb</packageName>
 							<outputDirectory>${project.build.directory}/generated-sources/jaxb/rexs-changelog</outputDirectory>
-                            <arguments>
-                                <argument>-Xxew</argument>
-                            </arguments>
+							<arguments>
+								<argument>-Xxew</argument>
+							</arguments>
 						</configuration>
 					</execution>
 				</executions>

--- a/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
@@ -31,7 +31,6 @@ import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.schema.jaxb.AllowedCombination;
 import info.rexs.schema.jaxb.AllowedCombinationRole;
-import info.rexs.schema.jaxb.AllowedCombinations;
 import info.rexs.schema.jaxb.Attribute;
 import info.rexs.schema.jaxb.Component;
 import info.rexs.schema.jaxb.ComponentAttributeMapping;
@@ -107,11 +106,10 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	private void generateRelationsWithAllowedCombinations(RexsVersion version, RexsSchema rexsModel) {
 		Map<RexsRelationType, List<List<AllowedCombinationRole>>> relationsToAllowedCombinationsMapofVersion = relationsToAllowedCombinationsMap.computeIfAbsent(version, k -> new HashMap<>());
 		if (rexsModel.getRelations() != null) {
-			for (Relation relation : rexsModel.getRelations().getRelation()) {
+			for (Relation relation : rexsModel.getRelations()) {
 				RexsRelationType relationType = RexsRelationType.findByKey(relation.getRelationId());
 				List<List<AllowedCombinationRole>> listOfCombinations = relationsToAllowedCombinationsMapofVersion.computeIfAbsent(relationType, k -> new ArrayList<>());
-				AllowedCombinations combinations = relation.getAllowedCombinations();
-				for (AllowedCombination combination : combinations.getAllowedCombination())
+				for (AllowedCombination combination : ( relation.getAllowedCombinations()))
 					listOfCombinations.add(combination.getAllowedCombinationRole());
 			}
 		}
@@ -119,7 +117,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 
 	private void generateComponentMap(RexsVersion version, RexsSchema rexsModel) {
 		Map<String, RexsComponentType> mapOfVersion = componentMap.computeIfAbsent(version, k -> new HashMap<>());
-		for (Component component : rexsModel.getComponents().getComponent()) {
+		for (Component component : rexsModel.getComponents()) {
 			RexsComponentType componentType = RexsComponentType.findById(component.getComponentId());
 			mapOfVersion.put(component.getComponentId(), componentType);
 		}
@@ -133,7 +131,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	 */
 	private void generateAttributeMap(RexsVersion version, RexsSchema rexsModel) {
 		Map<String, Attribute> mapofVersion = attributeMap.computeIfAbsent(version, k -> new HashMap<>());
-		for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+		for (Attribute attribute : rexsModel.getAttributes()) {
 			mapofVersion.put(attribute.getAttributeId(), attribute);
 		}
 	}
@@ -148,12 +146,12 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsValueType> mapofVersion = attributeTypes.computeIfAbsent(version, k -> new HashMap<>());
 		Map<Integer, String> valueTypeMap = new HashMap<>();
 		if (rexsModel.getValueTypes() != null) {
-			for (ValueType valueType : rexsModel.getValueTypes().getValueType()) {
+			for (ValueType valueType : rexsModel.getValueTypes()) {
 				valueTypeMap.put(valueType.getId(), valueType.getName());
 			}
 		}
 		if (rexsModel.getAttributes() != null) {
-			for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+			for (Attribute attribute : rexsModel.getAttributes()) {
 				mapofVersion.put(attribute.getAttributeId(), RexsValueType.findByKey(valueTypeMap.get(attribute.getValueType())));
 			}
 		}
@@ -163,7 +161,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsUnitId> mapofVersion = attributeUnits.computeIfAbsent(version, k -> new HashMap<>());
 		Map<Integer, String> unitMap = new HashMap<>();
 		if (rexsModel.getUnits() != null) {
-			for (Unit unit : rexsModel.getUnits().getUnit()) {
+			for (Unit unit : rexsModel.getUnits()) {
 				if (RexsStandardUnitIds.degree.getId().equals(unit.getName()))
 					unitMap.put(unit.getId(), RexsStandardUnitIds.deg.getId());
 				else
@@ -171,7 +169,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 			}
 		}
 		if (rexsModel.getAttributes() != null) {
-			for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+			for (Attribute attribute : rexsModel.getAttributes()) {
 				String unit = unitMap.get(attribute.getUnit());
 				mapofVersion.put(attribute.getAttributeId(), RexsUnitId.findById(unit));
 			}
@@ -245,7 +243,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	@Override
 	public String getNameForEnumValue(String attributeId, RexsVersion version, String value) {
 		Attribute attribute = attributeMap.get(version).get(attributeId);
-		for (EnumValue enumValue : attribute.getEnumValues().getEnumValue()) {
+		for (EnumValue enumValue : attribute.getEnumValues()) {
 			if (enumValue.getValue().equals(value)) {
 				if (getLanguageDefaultLocale().equals("de"))
 					return enumValue.getNameDe();
@@ -267,7 +265,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, List<RexsComponentType>> attributeToComponentMapofVersion = attributeToComponentMap.computeIfAbsent(version, k -> new HashMap<>());
 		Map<RexsComponentType, List<String>> componentToAttributeMapofVersion = componentToAttributesMap.computeIfAbsent(version, k -> new HashMap<>());
 		if (rexsModel.getComponentAttributeMappings() != null) {
-			for (ComponentAttributeMapping mapping : rexsModel.getComponentAttributeMappings().getComponentAttributeMapping()) {
+			for (ComponentAttributeMapping mapping : rexsModel.getComponentAttributeMappings()) {
 				RexsComponentType componentType = RexsComponentType.findById(mapping.getComponentId());
 				String attributeId = mapping.getAttributeId();
 

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
@@ -18,15 +18,15 @@ package info.rexs.upgrade.upgraders;
 import java.util.ArrayList;
 import java.util.List;
 
+import info.rexs.model.RexsAttribute;
+import info.rexs.model.RexsComponent;
+import info.rexs.model.RexsModel;
+import info.rexs.model.value.RexsAttributeValueScalar;
 import info.rexs.schema.constants.RexsAttributeId;
 import info.rexs.schema.constants.RexsComponentType;
 import info.rexs.schema.constants.RexsUnitId;
 import info.rexs.schema.constants.RexsValueType;
 import info.rexs.schema.constants.standard.RexsStandardUnitIds;
-import info.rexs.model.RexsAttribute;
-import info.rexs.model.RexsComponent;
-import info.rexs.model.RexsModel;
-import info.rexs.model.value.RexsAttributeValueScalar;
 import info.rexs.upgrade.RexsUpgradeException;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.AttributeSource;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.ComponentSource;
@@ -61,16 +61,16 @@ public class ModelChangelogUpgrader {
 
 	public RexsModel applyChangelog() throws RexsUpgradeException {
 		if (changelog.getComponentChanges() != null)
-			for (ComponentChange change : changelog.getComponentChanges().getComponentChange()) {
+			for (ComponentChange change : changelog.getComponentChanges()) {
 				if (change.getType() == ChangeType.DELETE)
 					deleteComponentsByType(newModel, change.getId());
 
 				if (change.getType() == ChangeType.EDIT)
-					editComponentsByType(change.getId(), change.getChangedValues().getChangedValue());
+					editComponentsByType(change.getId(), change.getChangedValues());
 			}
 
 		if (changelog.getMappingChanges() != null)
-			for (MappingChange change : changelog.getMappingChanges().getMappingChange()) {
+			for (MappingChange change : changelog.getMappingChanges()) {
 				if (change.getType() == ChangeType.DELETE) {
 					if (strictMode) {
 						deleteAttributesByComponentTypeAndAttributeId(newModel, change.getComponentId(), change.getAttributeId());
@@ -81,9 +81,9 @@ public class ModelChangelogUpgrader {
 			}
 
 		if (changelog.getAttributeChanges() != null)
-			for (AttributeChange change : changelog.getAttributeChanges().getAttributeChange()) {
+			for (AttributeChange change : changelog.getAttributeChanges()) {
 				if (change.getType() == ChangeType.EDIT)
-					editAttributesById(change.getId(), change.getChangedValues().getChangedValue());
+					editAttributesById(change.getId(), change.getChangedValues());
 			}
 
 		return newModel;
@@ -233,7 +233,7 @@ public class ModelChangelogUpgrader {
 
 
 	private void changeEnumValue(RexsAttribute attribute, ChangedValue changedValue) {
-		for (EnumValueChange enumChange: changedValue.getEnumValueChanges().getEnumValueChange()) {
+		for (EnumValueChange enumChange: changedValue.getEnumValueChanges()) {
 			switch (enumChange.getType()) {
 			case ADD: {
 				// Do nothing. Change must be handled by custom upgrade.
@@ -246,7 +246,7 @@ public class ModelChangelogUpgrader {
 			case EDIT: {
 				String attrValue = attribute.getStringValue();
 				if (attrValue.equals(enumChange.getValue())) {
-					ChangedValue changedEnumValue = enumChange.getChangedValues().getChangedValue().get(0);
+					ChangedValue changedEnumValue = enumChange.getChangedValues().get(0);
 					String newName = changedEnumValue.getNewValue();
 					attribute.setStringValue(newName);
 				}

--- a/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
@@ -78,19 +78,19 @@ public class RexsSchemaResolverTest {
 			RexsSchema rexsModel = RexsSchemaResolver.getInstance().resolve(version);
 			assertThat(rexsModel.getVersion()).isEqualTo(version.getName());
 
-			for (Unit unit : rexsModel.getUnits().getUnit()) {
+			for (Unit unit : rexsModel.getUnits()) {
 				assertThat(RexsUnitId.findById(unit.getName())).isNotNull();
 			}
 
-			for (ValueType valueType : rexsModel.getValueTypes().getValueType()) {
+			for (ValueType valueType : rexsModel.getValueTypes()) {
 				assertThat(info.rexs.schema.constants.RexsValueType.findByKey(valueType.getName())).isNotNull();
 			}
 
-			for (Component component : rexsModel.getComponents().getComponent()) {
+			for (Component component : rexsModel.getComponents()) {
 				assertThat(RexsComponentType.findById(component.getComponentId())).isNotNull();
 			}
 
-			for (Attribute attribute : rexsModel.getAttributes().getAttribute()) {
+			for (Attribute attribute : rexsModel.getAttributes()) {
 				assertThat(RexsAttributeId.findById(attribute.getAttributeId())).isNotNull();
 			}
 		}

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
@@ -69,9 +69,9 @@ public class ChangelogResolverTest {
 			assertThat(rexsChangelog.getToVersion()).isEqualTo(changelogFile.getToVersion().getName());
 
 			int countChangelogChanges = 0;
-			countChangelogChanges += rexsChangelog.getComponentChanges() != null ? rexsChangelog.getComponentChanges().getComponentChange().size() : 0;
-			countChangelogChanges += rexsChangelog.getAttributeChanges() != null ? rexsChangelog.getAttributeChanges().getAttributeChange().size() : 0;
-			countChangelogChanges += rexsChangelog.getMappingChanges() != null ? rexsChangelog.getMappingChanges().getMappingChange().size() : 0;
+			countChangelogChanges += rexsChangelog.getComponentChanges() != null ? rexsChangelog.getComponentChanges().size() : 0;
+			countChangelogChanges += rexsChangelog.getAttributeChanges() != null ? rexsChangelog.getAttributeChanges().size() : 0;
+			countChangelogChanges += rexsChangelog.getMappingChanges() != null ? rexsChangelog.getMappingChanges().size() : 0;
 			assertThat(countChangelogChanges).isGreaterThan(0);
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,13 @@
 				<version>1.82</version>
 			</dependency>
 
+			<!-- JAXB @XmlElementWrapper Plugin (see https://github.com/dmak/jaxb-xew-plugin) -->
+			<dependency>
+				<groupId>com.github.jaxb-xew-plugin</groupId>
+				<artifactId>jaxb-xew-plugin</artifactId>
+				<version>2.1</version>
+			</dependency>
+
 			<!-- Modules -->
 			<dependency>
 				<groupId>${project.groupId}</groupId>


### PR DESCRIPTION
By using the plugin `jaxb-xew-plugin`, element wrappers are used instead of wrapper classes.
This allows easier access to list data in JAXB classes.

fixes #174 