### PR TITLE
RexsVersion with distinction in schemaVersion and modelVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JAXB classes are now using element wrappers instead of wrapper classes
+- RexsVersion with distinction in schemaVersion and modelVersion
 
 
 ## [0.10.0] - 2024-11-05

--- a/api/src/main/java/info/rexs/io/json/RexsJsonFileWriter.java
+++ b/api/src/main/java/info/rexs/io/json/RexsJsonFileWriter.java
@@ -153,12 +153,12 @@ public class RexsJsonFileWriter extends AbstractRexsFileWriter {
 			return;
 
 		String versionName = model.getVersion();
-		RexsVersion version = RexsVersion.findByName(versionName);
+		RexsVersion version = RexsVersion.findByModelVersion(versionName);
 		if (version == null)
 			return;
 
-		RexsUnitId searchUnit = version.isLess(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.deg : RexsStandardUnitIds.degree;
-		RexsUnitId replaceUnit = version.isLess(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.degree : RexsStandardUnitIds.deg;
+		RexsUnitId searchUnit = version.isLessThan(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.deg : RexsStandardUnitIds.degree;
+		RexsUnitId replaceUnit = version.isLessThan(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.degree : RexsStandardUnitIds.deg;
 
 		List<Component> allComponents = new ArrayList<>();
 		allComponents.addAll(model.getComponents());

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
@@ -22,7 +22,7 @@ public class StringAttribute extends Attribute {
 
     @JsonProperty("string")
     private String string;
-    
+
 
     @JsonProperty("string")
     public String getString() {
@@ -73,8 +73,8 @@ public class StringAttribute extends Attribute {
             return false;
         }
         StringAttribute rhs = ((StringAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.string.equals(rhs.getString());
     }
 

--- a/api/src/main/java/info/rexs/io/xml/RexsXmlFileWriter.java
+++ b/api/src/main/java/info/rexs/io/xml/RexsXmlFileWriter.java
@@ -121,12 +121,12 @@ public class RexsXmlFileWriter extends AbstractRexsFileWriter {
 			return model;
 
 		String versionName = model.getVersion();
-		RexsVersion version = RexsVersion.findByName(versionName);
+		RexsVersion version = RexsVersion.findByModelVersion(versionName);
 		if (version == null)
 			return model;
 
-		RexsUnitId searchUnit = version.isLess(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.deg : RexsStandardUnitIds.degree;
-		RexsUnitId replaceUnit = version.isLess(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.degree : RexsStandardUnitIds.deg;
+		RexsUnitId searchUnit = version.isLessThan(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.deg : RexsStandardUnitIds.degree;
+		RexsUnitId replaceUnit = version.isLessThan(RexsStandardVersions.V1_4) ? RexsStandardUnitIds.degree : RexsStandardUnitIds.deg;
 
 		List<Component> allComponents = new ArrayList<>();
 		allComponents.addAll(model.getComponents().getComponent());

--- a/api/src/main/java/info/rexs/model/RexsModel.java
+++ b/api/src/main/java/info/rexs/model/RexsModel.java
@@ -83,7 +83,7 @@ public class RexsModel {
 	 * 				Version of the application.
 	 */
 	public RexsModel(String version, String applicationId, String applicationVersion) {
-		this.version = RexsVersion.findByName(version);
+		this.version = RexsVersion.findByModelVersion(version);
 		this.originVersion = version;
 		this.applicationId = applicationId;
 		this.applicationVersion = applicationVersion;
@@ -118,7 +118,7 @@ public class RexsModel {
 	 */
 	protected RexsModel(RexsVersion version, String applicationId, String applicationVersion) {
 		this.version = version;
-		this.originVersion = version.getName();
+		this.originVersion = version.getModelVersion();
 		this.applicationId = applicationId;
 		this.applicationVersion = applicationVersion;
 	}

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
@@ -13,7 +13,6 @@ import info.rexs.schema.constants.RexsVersion;
 import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
 import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 import info.rexs.schema.constants.standard.RexsStandardUnitIds;
-import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.io.json.model.Accumulation;
 import info.rexs.io.json.model.Component;
 import info.rexs.io.json.model.FloatingPointArrayCoded;
@@ -72,18 +71,16 @@ import info.rexs.model.value.RexsAttributeValueScalar;
  */
 public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel>{
 
-
-
 	private RexsVersion version;
 
 	@Override
 	public JSONModel transform(RexsModel model) {
-		version = model.getVersion().equals(RexsStandardVersions.UNKNOWN) ? RexsVersion.create(model.getOriginVersion(), 0) : model.getVersion();
+		version = model.getVersion();
 		return new JSONModel().withModel(new Model()
 				.withDate(DateUtils.getISO8601Date())
 				.withApplicationId(model.getApplicationId())
 				.withApplicationVersion(model.getApplicationVersion())
-				.withVersion(version.getName())
+				.withVersion(model.getVersion().equals(RexsVersion.UNKNOWN) ? model.getOriginVersion() : model.getVersion().getModelVersion())
 				.withComponents(createComponentsJson(model.getComponents()))
 				.withRelations(createRelationsJson(model.getRelations()))
 				.withLoadSpectrum(createLoadSpectrumsJson(model.getLoadSpectrums())));

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import info.rexs.schema.constants.RexsVersion;
 import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
 import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 import info.rexs.schema.constants.standard.RexsStandardUnitIds;
-import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.model.RexsAttribute;
 import info.rexs.model.RexsComponent;
 import info.rexs.model.RexsLoadSpectrum;
@@ -96,10 +96,10 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 		modelXml.setApplicationVersion(model.getApplicationVersion());
 		modelXml.setDate(DateUtils.getISO8601Date());
 
-		if (model.getVersion().equals(RexsStandardVersions.UNKNOWN)) {
+		if (model.getVersion().equals(RexsVersion.UNKNOWN)) {
 			modelXml.setVersion(model.getOriginVersion());
 		} else {
-			modelXml.setVersion(model.getVersion().getName());
+			modelXml.setVersion(model.getVersion().getModelVersion());
 		}
 
 		modelXml.setRelations(createRelationsXml(model.getRelations()));

--- a/api/src/main/java/info/rexs/schema/RexsSchemaFileResolver.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaFileResolver.java
@@ -17,6 +17,8 @@ package info.rexs.schema;
 
 import java.io.InputStream;
 
+import info.rexs.schema.constants.RexsVersion;
+
 /**
  * This class is used to determine the content of REXS schema files.
  * <p>
@@ -36,7 +38,10 @@ public class RexsSchemaFileResolver {
 	 * 				The {@link InputStream} of the file.
 	 */
 	public InputStream openInputStream(RexsSchemaFile rexsSchemaFile) {
-		String rexsSchemaFilename = String.format("rexs_schema_%s.xml", rexsSchemaFile.getVersion().getModelVersion());
+		RexsVersion version = rexsSchemaFile.getVersion();
+		String rexsSchemaFilename = version.getSchemaProvider() == null
+			? String.format("rexs_schema_%s.xml", version.getSchemaVersion())
+			: String.format("rexs_schema_%s_%s.xml", version.getSchemaVersion(), version.getSchemaProvider());
 		return rexsSchemaFile.getClass().getResourceAsStream(rexsSchemaFilename);
 	}
 }

--- a/api/src/main/java/info/rexs/schema/RexsSchemaFileResolver.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaFileResolver.java
@@ -36,7 +36,7 @@ public class RexsSchemaFileResolver {
 	 * 				The {@link InputStream} of the file.
 	 */
 	public InputStream openInputStream(RexsSchemaFile rexsSchemaFile) {
-		String rexsSchemaFilename = String.format("rexs_schema_%s.xml", rexsSchemaFile.getVersion().getName());
+		String rexsSchemaFilename = String.format("rexs_schema_%s.xml", rexsSchemaFile.getVersion().getModelVersion());
 		return rexsSchemaFile.getClass().getResourceAsStream(rexsSchemaFilename);
 	}
 }

--- a/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaRegistry.java
@@ -89,9 +89,9 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	public void registerRexsVersion(RexsVersion version) {
 		RexsSchema rexsSchema = RexsSchemaResolver.getInstance().resolve(version);
 		if (rexsSchema == null)
-			throw new IllegalStateException(String.format("rexs db model for version %s not found", version.getName()));
+			throw new IllegalStateException(String.format("rexs db model for version %s not found", version.getModelVersion()));
 		registerRexsSchema(version, rexsSchema);
-		versions.put(version.getName(), version);
+		versions.put(version.getModelVersion(), version);
 	}
 
 	private void registerRexsSchema(RexsVersion version, RexsSchema rexsSchema) {
@@ -187,7 +187,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsUnitId> unitsMap = attributeUnits.get(version);
 		if (unitsMap != null && (unitsMap.containsKey(rexsAttributeId)) )
 			return unitsMap.get(rexsAttributeId);
-		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getName()));
+		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getModelVersion()));
 	}
 
 	/**
@@ -201,7 +201,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, RexsValueType> map = attributeTypes.get(version);
 		if (map != null && (map.containsKey(rexsAttributeId)) )
 			return map.get(rexsAttributeId);
-		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getName()));
+		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getModelVersion()));
 	}
 
 	/**
@@ -303,7 +303,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<String, List<RexsComponentType>> map = attributeToComponentMap.get(version);
 		if (map != null && (map.containsKey(rexsAttributeId)) )
 			return map.get(rexsAttributeId);
-		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getName()));
+		throw new IllegalArgumentException(String.format("Rexs Attribute with id %s is not registered in RexsVersion %s", rexsAttributeId, version.getModelVersion()));
 	}
 
 	/**
@@ -317,7 +317,7 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 		Map<RexsComponentType, List<String>> map = componentToAttributesMap.get(version);
 		if (map != null && (map.containsKey(rexsComponentType)) )
 			return map.get(rexsComponentType);
-		throw new IllegalArgumentException(String.format("Rexs component type %s is not registered in RexsVersion %s", rexsComponentType, version.getName()));
+		throw new IllegalArgumentException(String.format("Rexs component type %s is not registered in RexsVersion %s", rexsComponentType, version.getModelVersion()));
 	}
 
 	@Override
@@ -357,10 +357,10 @@ public class RexsSchemaRegistry implements IRexsSchemaRegistry {
 	public List<List<AllowedCombinationRole>> getAllowedCombinationsForRelation(RexsVersion version, RexsRelationType relationType) {
 		Map<RexsRelationType, List<List<AllowedCombinationRole>>> relationsToAllowedCombinationsMapOfVersion = relationsToAllowedCombinationsMap.get(version);
 		if (relationsToAllowedCombinationsMapOfVersion==null)
-			throw new IllegalArgumentException(String.format("No relation types for REXS version %s specified", version.getName()));
+			throw new IllegalArgumentException(String.format("No relation types for REXS version %s specified", version.getModelVersion()));
 		List<List<AllowedCombinationRole>> listOfAllowedCombinations = relationsToAllowedCombinationsMapOfVersion.get(relationType);
 		if (listOfAllowedCombinations==null || listOfAllowedCombinations.isEmpty())
-			throw new IllegalArgumentException(String.format("Rexs Relation type %s is not defined in version %s", relationType, version.getName()));
+			throw new IllegalArgumentException(String.format("Rexs Relation type %s is not defined in version %s", relationType, version.getModelVersion()));
 		return listOfAllowedCombinations;
 	}
 }

--- a/api/src/main/java/info/rexs/schema/constants/standard/RexsStandardVersions.java
+++ b/api/src/main/java/info/rexs/schema/constants/standard/RexsStandardVersions.java
@@ -1,56 +1,62 @@
-/*
- * Copyright (C) 2020 FVA GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License.  You may obtain a copy
- * of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package info.rexs.schema.constants.standard;
 
 import info.rexs.schema.constants.RexsVersion;
 
 /**
- * Standard REXS versions.
- *
- * @see RexsVersion
- * @see <a href="https://database.rexs.info/rexs/version/list">REXS Database</a>
+ * The standard versions of the REXS (Reusable Engineering EXchange Standard) schema.
  */
-public interface RexsStandardVersions {
+public final class RexsStandardVersions {
 
-	/** REXS version 1.0. */
-	RexsVersion V1_0 = RexsVersion.create("1.0", 1000, "0.90", "0.10", "1.00");
+	/**
+	 * Version 1.0 of the REXS schema.
+	 */
+	public static final RexsVersion V1_0 = RexsVersion.create("1.0", null, "1.0", "0.90", "0.10", "1.00");
 
-	/** REXS version 1.1. */
-	RexsVersion V1_1 = RexsVersion.create("1.1", 1100, "1.10", "1.1-Beta");
+	/**
+	 * Version 1.1 of the REXS schema.
+	 */
+	public static final RexsVersion V1_1 = RexsVersion.create("1.1", null, "1.1", "1.10", "1.1-Beta");
 
-	/** REXS version 1.2. */
-	RexsVersion V1_2 = RexsVersion.create("1.2", 1200);
+	/**
+	 * Version 1.2 of the REXS schema.
+	 */
+	public static final RexsVersion V1_2 = RexsVersion.create("1.2", null, "1.2");
 
-	/** REXS version 1.3. */
-	RexsVersion V1_3 = RexsVersion.create("1.3", 1300);
+	/**
+	 * Version 1.3 of the REXS schema.
+	 */
+	public static final RexsVersion V1_3 = RexsVersion.create("1.3", null, "1.3");
 
-	/** REXS version 1.4. */
-	RexsVersion V1_4 = RexsVersion.create("1.4", 1400);
+	/**
+	 * Version 1.4 of the REXS schema.
+	 */
+	public static final RexsVersion V1_4 = RexsVersion.create("1.4", null, "1.4");
 
-	/** REXS version 1.5. */
-	RexsVersion V1_5 = RexsVersion.create("1.5", 1500);
+	/**
+	 * Version 1.5 of the REXS schema.
+	 */
+	public static final RexsVersion V1_5 = RexsVersion.create("1.5", null, "1.5");
 
-	/** REXS version 1.6. */
-	RexsVersion V1_6 = RexsVersion.create("1.6", 1600);
+	/**
+	 * Version 1.6 of the REXS schema.
+	 */
+	public static final RexsVersion V1_6 = RexsVersion.create("1.6", null, "1.6");
 
-	/** Constant for the current development version. */
-	RexsVersion DEV = RexsVersion.create("DEV", 9999);
+	/**
+	 * @return
+	 * 				The latest official REXS {@link RexsVersion}.
+	 */
+	public static RexsVersion getLatest() {
+		return V1_6;
+	}
 
-	/** Constant for an unknown version. */
-	RexsVersion UNKNOWN = RexsVersion.create("unknown", -1);
+	/**
+	 * Initializes the standard versions.
+	 */
+	public static void init() {
+		// necessary to initialize the standard versions
+	}
 
-	static void init() {}
+	/** private constructor to prevent instantiation */
+	private RexsStandardVersions() {}
 }

--- a/api/src/main/java/info/rexs/upgrade/RexsUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/RexsUpgrader.java
@@ -64,7 +64,7 @@ public class RexsUpgrader {
 	 * 				If an unexpected error occurs during the upgrade process.
 	 */
 	public ModelUpgraderResult upgrade() throws RexsUpgradeException {
-		return upgrade(RexsVersion.getLatest(), false);
+		return upgrade(RexsStandardVersions.getLatest(), false);
 	}
 
 	/**
@@ -80,7 +80,7 @@ public class RexsUpgrader {
 	 */
 	public ModelUpgraderResult upgrade(RexsVersion toVersion, boolean strictMode) throws RexsUpgradeException {
 		RexsVersion fromVersion = rexsModel.getVersion();
-		if (fromVersion == null || fromVersion.equals(RexsStandardVersions.UNKNOWN))
+		if (fromVersion == null || fromVersion.equals(RexsVersion.UNKNOWN))
 			throw new RexsUpgradeException(String.format("unknown version %s", rexsModel.getVersion()));
 
 		List<Notification> notifications = new ArrayList<>();

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileResolver.java
@@ -36,7 +36,7 @@ public class ChangelogFileResolver {
 	 * 				The {@link InputStream} of the file.
 	 */
 	public InputStream openInputStream(ChangelogFile changelogFile) {
-		String changelogFilename = String.format("rexs_changelog_%s_to_%s.xml", changelogFile.getFromVersion().getName(), changelogFile.getToVersion().getName());
+		String changelogFilename = String.format("rexs_changelog_%s_to_%s.xml", changelogFile.getFromVersion().getModelVersion(), changelogFile.getToVersion().getModelVersion());
 		return changelogFile.getClass().getResourceAsStream(changelogFilename);
 	}
 }

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolver.java
@@ -76,7 +76,7 @@ public class ChangelogResolver {
 			Unmarshaller unmarshaller = context.createUnmarshaller();
 			changelog = (RexsChangelog)unmarshaller.unmarshal(input);
 		} catch (Exception ex) {
-			throw new RexsUpgradeException(String.format("could not load rexs changelog for version %s to version %s", changelogFile.getFromVersion().getName(), changelogFile.getToVersion().getName()), ex);
+			throw new RexsUpgradeException(String.format("could not load rexs changelog for version %s to version %s", changelogFile.getFromVersion().getModelVersion(), changelogFile.getToVersion().getModelVersion()), ex);
 		}
 
 		changelogFileCache.put(changelogFile, changelog);

--- a/api/src/main/java/info/rexs/validation/RexsStandardModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardModelValidator.java
@@ -75,7 +75,7 @@ public class RexsStandardModelValidator extends DefaultRexsModelValidator {
 		RexsValidationResult validationResult = super.validate(rexsModel);
 
 		if (!rexsSchemaRegistry.hasRelationTypes(rexsVersion))
-			validationResult.addWarning(RexsValidationResultMessageKey.RELATION_NO_TYPES_FOR_VERSION, rexsVersion.getName());
+			validationResult.addWarning(RexsValidationResultMessageKey.RELATION_NO_TYPES_FOR_VERSION, rexsVersion.getModelVersion());
 
 		validationResult.add(checkPlanetaryStage(rexsModel));
 

--- a/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
@@ -27,6 +27,7 @@ import java.nio.file.StandardOpenOption;
 
 import org.junit.Test;
 
+import info.rexs.schema.constants.RexsVersion;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.io.RexsIoException;
 import info.rexs.model.RexsModel;
@@ -67,7 +68,7 @@ public class RexsXmlFileReaderTest {
 		Model rawModel = reader.readRawModel();
 
 		assertThat(rawModel).isNotNull();
-		assertThat(rawModel.getVersion()).isEqualTo(RexsStandardVersions.V1_1.getName());
+		assertThat(rawModel.getVersion()).isEqualTo(RexsStandardVersions.V1_1.getModelVersion());
 		assertThat(rawModel.getComponents().getComponent().size()).isEqualTo(97);
 		assertThat(rawModel.getRelations().getRelation().size()).isEqualTo(140);
 	}

--- a/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
@@ -67,7 +67,8 @@ public class RexsSchemaFileTest {
 
 	@Test
 	public void findByVersion_givenUnknownVersionReturnsNull() {
-		assertThat(RexsSchemaFile.findByVersion(RexsVersion.create("m.n", 10000))).isNull();
+		RexsVersion versionWithNoSchema = RexsVersion.create("66.6", null, "66.6");
+		assertThat(RexsSchemaFile.findByVersion(versionWithNoSchema)).isNull();
 	}
 
 	@Test
@@ -79,18 +80,18 @@ public class RexsSchemaFileTest {
 
 	@Test
 	public void findByVersion_returnsNewlyCreatedRexsSchemaFile() throws Exception {
-		RexsVersion newVersion = RexsVersion.create("n.o", 11000);
+		RexsVersion newVersion = RexsVersion.create("66.7", null, "66.7");
 		RexsSchemaFile.create(newVersion);
 		RexsSchemaFile newRexsSchemaFile = RexsSchemaFile.findByVersion(newVersion);
 		assertThat(newRexsSchemaFile).isNotNull();
-		assertThat(newRexsSchemaFile.getVersion().getName()).isEqualTo("n.o");
+		assertThat(newRexsSchemaFile.getVersion().getModelVersion()).isEqualTo("66.7");
 	}
 
 	@Test
 	public void equals_equalObjects() {
 		assertThat(RexsSchemaFile.V1_0.equals(RexsSchemaFile.V1_0)).isTrue();
 
-		RexsVersion newVersion = RexsVersion.create("o.p", 12000);
+		RexsVersion newVersion = RexsVersion.create("66.8", null, "66.8");
 		assertThat(RexsSchemaFile.create(newVersion)).isEqualTo(RexsSchemaFile.create(newVersion));
 	}
 
@@ -99,8 +100,8 @@ public class RexsSchemaFileTest {
 		assertThat(RexsSchemaFile.V1_1).isNotEqualTo(RexsSchemaFile.V1_2);
 		assertThat(RexsSchemaFile.V1_1).isNotEqualTo("test");
 
-		RexsVersion newVersion1 = RexsVersion.create("p.q", 13000);
-		RexsVersion newVersion2 = RexsVersion.create("q.r", 14000);
+		RexsVersion newVersion1 = RexsVersion.create("6.66", null, "6.66");
+		RexsVersion newVersion2 = RexsVersion.create("66.66", null, "66.66");
 		assertThat(RexsSchemaFile.create(newVersion1)).isNotEqualTo(RexsSchemaFile.create(newVersion2));
 	}
 }

--- a/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
@@ -39,7 +39,7 @@ public class RexsSchemaResolverTest {
 
 	@Test
 	public void resolve_unknownRexsSchemaFileReturnsNull() throws Exception {
-		RexsVersion newVersion = RexsVersion.create("r.s", 10000);
+		RexsVersion newVersion = RexsVersion.create("67.6", null, "67.6");
 		assertThat(RexsSchemaResolver.getInstance().resolve(newVersion)).isNull();
 
 		assertThat(RexsSchemaResolver.getInstance().resolve(null)).isNull();
@@ -47,7 +47,7 @@ public class RexsSchemaResolverTest {
 
 	@Test
 	public void resolve_invalidRexsSchemaFileResolverThrowsIllegalStateException() throws Exception {
-		RexsVersion newVersion = RexsVersion.create("s.t", 11000);
+		RexsVersion newVersion = RexsVersion.create("68.6", null, "68.6");
 		RexsSchemaFile.create(newVersion, new RexsSchemaFileResolver() {
 			@Override
 			public InputStream openInputStream(RexsSchemaFile rexsSchemaFile) {
@@ -64,8 +64,8 @@ public class RexsSchemaResolverTest {
 
 	@Test
 	public void resolve_cachingReturnsSameObjectForMultipleCalls() throws Exception {
-		RexsSchema rexsSchema1 = RexsSchemaResolver.getInstance().resolve(RexsVersion.getLatest());
-		RexsSchema rexsSchema2 = RexsSchemaResolver.getInstance().resolve(RexsVersion.getLatest());
+		RexsSchema rexsSchema1 = RexsSchemaResolver.getInstance().resolve(RexsStandardVersions.getLatest());
+		RexsSchema rexsSchema2 = RexsSchemaResolver.getInstance().resolve(RexsStandardVersions.getLatest());
 
 		assertThat(rexsSchema1).isSameAs(rexsSchema2);
 	}
@@ -75,7 +75,7 @@ public class RexsSchemaResolverTest {
 		List<RexsVersion> rexsStandardVersions = Stream.of(RexsStandardVersions.V1_0, RexsStandardVersions.V1_1, RexsStandardVersions.V1_2).collect(Collectors.toList());
 		for (RexsVersion version : rexsStandardVersions) {
 			RexsSchema rexsSchema = RexsSchemaResolver.getInstance().resolve(version);
-			assertThat(rexsSchema.getVersion()).isEqualTo(version.getName());
+			assertThat(rexsSchema.getVersion()).isEqualTo(version.getModelVersion());
 
 			for (Unit unit : rexsSchema.getUnits()) {
 				assertThat(RexsUnitId.findById(unit.getName())).isNotNull();

--- a/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
@@ -1,139 +1,306 @@
-/*
- * Copyright (C) 2020 FVA GmbH
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License.  You may obtain a copy
- * of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
 package info.rexs.schema.constants;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.Test;
 
-import info.rexs.schema.constants.standard.RexsStandardVersions;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class RexsVersionTest {
 
 	@Test
-	public void getLatest_returnsNotNull() {
-		assertThat(RexsVersion.getLatest()).isNotNull();
+	public void create_whenValidInput_thenCreatesVersion() {
+		// provider-specific version
+		RexsVersion version = RexsVersion.create("1.0", "provider", "1.0");
+		assertNotNull(version);
+		assertEquals("1.0", version.getSchemaVersion());
+		assertEquals("provider", version.getSchemaProvider());
+		assertEquals("1.0", version.getModelVersion());
+		assertEquals(10000, version.getNumericVersion());
+
+		// provider-specific DEV version
+		version = RexsVersion.create("DEV", "ACME", "DEVACME");
+		assertNotNull(version);
+		assertEquals("DEV", version.getSchemaVersion());
+		assertEquals("ACME", version.getSchemaProvider());
+		assertEquals("DEVACME", version.getModelVersion());
+		assertEquals(Integer.MAX_VALUE, version.getNumericVersion());
 	}
 
 	@Test
-	public void create_givenNullThrowsIllegalArgumentException() {
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> RexsVersion.create(null, 1))
-			.withMessage("name cannot be empty");
+	public void create_whenEmptyProvider_thenProviderIsNull() {
+		RexsVersion version = RexsVersion.create("1.0", "", "1.0");
+		assertNotNull(version);
+		assertNull(version.getSchemaProvider());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenSchemaVersionIsEmpty_thenThrowsException() {
+		RexsVersion.create("", "provider", "1.0");
+	}
+
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenSchemaVersionIsNull_thenThrowsException() {
+		RexsVersion.create(null, "provider", "1.0");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenPrimaryModelVersionIsEmpty_thenThrowsException() {
+		RexsVersion.create("1.0", "provider", "");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenPrimaryModelVersionIsNull_thenThrowsException() {
+		RexsVersion.create("1.0", "provider", null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenAdditionalModelVersionIsEmpty_thenThrowsException() {
+		RexsVersion.create("1.0", "provider", "1.0", "1.0.0", "");
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenAdditionalModelVersionIsNull_thenThrowsException() {
+		RexsVersion.create("1.0", "provider", "1.0", "1.0.0", null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void create_whenSchemaVersionPatternIsInvalid_thenThrowsException() {
+		RexsVersion.create("1", "provider", "1.0");
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() {
-		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> RexsVersion.create("", 1))
-			.withMessage("name cannot be empty");
+	public void findByModelVersion_whenModelVersionExists_thenReturnsVersion() {
+		// provider-specific version
+		RexsVersion v10pro = RexsVersion.create("1.0", "provider", "1.0 PROVIDER");
+		RexsVersion version = RexsVersion.findByModelVersion("1.0 PROVIDER");
+		assertNotNull(version);
+		assertEquals(v10pro, version);
+
+		// DEV
+		RexsVersion dev1 = RexsVersion.findByModelVersion("dev");
+		RexsVersion dev2 = RexsVersion.findByModelVersion("DEV");
+		assertEquals(RexsVersion.DEV, dev1);
+		assertEquals(RexsVersion.DEV, dev2);
 	}
 
 	@Test
-	public void create_givenNullAlternativeNamesDoesNotCrash() {
-		RexsVersion newVersion = RexsVersion.create("a.b", 1, (String[])null);
-		assertThat(newVersion.getName()).isEqualTo("a.b", 1);
+	public void findByModelVersion_whenModelVersionDoesNotExist_thenReturnsUnknown() {
+		RexsVersion version = RexsVersion.findByModelVersion("nonexistent");
+		assertNotNull(version);
+		assertEquals(RexsVersion.UNKNOWN, version);
 	}
 
 	@Test
-	public void create_newVersionHasName() {
-		RexsVersion newVersion = RexsVersion.create("a.b", 1);
-		assertThat(newVersion.getName()).isEqualTo("a.b", 1);
+	public void findByModelVersion_whenModelVersionIsNull_thenReturnsUnknown() {
+		RexsVersion version = RexsVersion.findByModelVersion(null);
+		assertEquals(RexsVersion.UNKNOWN, version);
 	}
 
 	@Test
-	public void findByName_givenNullReturnsUnknown() {
-		assertThat(RexsVersion.findByName(null)).isEqualTo(RexsStandardVersions.UNKNOWN);
+	public void findBySchema_whenSchemaVersionIsNull_thenReturnsUnknown() {
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema(null, "provider"));
 	}
 
 	@Test
-	public void findByName_givenUnknownNameReturnsUnknown() {
-		assertThat(RexsVersion.findByName("foo.bar")).isEqualTo(RexsStandardVersions.UNKNOWN);
+	public void findBySchema_whenSchemaProviderIsEmpty_thenTreatAsNull() {
+		RexsVersion version = RexsVersion.create("1.0", null, "1.0");
+		assertEquals(version, RexsVersion.findBySchema("1.0", ""));
 	}
 
 	@Test
-	public void findByName_returnsRexsStandardVersion() {
-		RexsVersion version = RexsVersion.findByName(RexsStandardVersions.V1_0.getName());
-		assertThat(version).isNotNull();
-		assertThat(version.getName()).isEqualTo(RexsStandardVersions.V1_0.getName());
+	public void findBySchema_whenSchemaVersionAndProviderMatch_thenReturnsVersion() {
+		RexsVersion version = RexsVersion.create("1.0", "provider", "1.0");
+		assertEquals(version, RexsVersion.findBySchema("1.0", "provider"));
 	}
 
 	@Test
-	public void findByName_returnsNewlyCreatedVersion() {
-		RexsVersion.create("b.c", 1);
-		RexsVersion newVersion = RexsVersion.findByName("b.c");
-		assertThat(newVersion).isNotNull();
-		assertThat(newVersion.getName()).isEqualTo("b.c");
+	public void findBySchema_whenSchemaVersionMatchesWithoutProvider_thenReturnsVersion() {
+		RexsVersion version = RexsVersion.create("1.0", null, "1.0");
+		assertEquals(version, RexsVersion.findBySchema("1.0", null));
 	}
 
 	@Test
-	public void findByName_returnsNewlyCreatedVersionByAlternativeVersionName() {
-		RexsVersion.create("c.d", 1, "d.e", "e.f");
-
-		RexsVersion newVersionByName = RexsVersion.findByName("c.d");
-		assertThat(newVersionByName).isNotNull();
-		assertThat(newVersionByName.getName()).isEqualTo("c.d");
-
-		RexsVersion newVersionByAlternativeName = RexsVersion.findByName("d.e");
-		assertThat(newVersionByAlternativeName).isNotNull();
-		assertThat(newVersionByAlternativeName.getName()).isEqualTo("c.d");
-
-		newVersionByAlternativeName = RexsVersion.findByName("e.f");
-		assertThat(newVersionByAlternativeName).isNotNull();
-		assertThat(newVersionByAlternativeName.getName()).isEqualTo("c.d");
+	public void findBySchema_whenSchemaVersionMatchesButProviderDoesNot_thenReturnsUnknown() {
+		RexsVersion.create("1.0", "provider1", "1.0");
+		RexsVersion.create("200.0", "provider200", "200.0 provider200");
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema("1.0", "provider2"));
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema("99.99", ""));
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema("200.0", ""));
 	}
 
 	@Test
-	public void isLessOrEqual_whenVersionIsLessOrEqual_returnsTrue() {
-		assertThat(RexsStandardVersions.V1_0.isLessOrEqual(RexsStandardVersions.V1_1)).isTrue();
-		assertThat(RexsStandardVersions.V1_1.isLessOrEqual(RexsStandardVersions.V1_1)).isTrue();
-		assertThat(RexsStandardVersions.V1_2.isLessOrEqual(RexsStandardVersions.V1_1)).isFalse();
+	public void findBySchema_whenSchemaVersionDoesNotMatch_thenReturnsUnknown() {
+		RexsVersion.create("1.0", "provider", "1.0");
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema("7.0", "provider"));
 	}
 
 	@Test
-	public void isEqual_whenVersionIsEqual_returnsTrue() {
-		RexsVersion V1_1_copy = RexsVersion.create("1.1", 1100);
+	public void equals_whenSameSchemaAndProvider_thenReturnsTrue() {
+		// without provider
+		RexsVersion version1 = RexsVersion.create("1.0", null, "1.0");
+		RexsVersion version2 = RexsVersion.create("1.0", null, "1.0 whatever");
+		assertEquals(version1, version2);
 
-		assertThat(RexsStandardVersions.V1_1.isEqual(V1_1_copy)).isTrue();
-		assertThat(RexsStandardVersions.V1_1.isEqual(RexsStandardVersions.V1_1)).isTrue();
+		// with provider
+		RexsVersion version1pro = RexsVersion.create("1.0", "provider", "1.0 PROVIDER");
+		RexsVersion version2pro = RexsVersion.create("1.0", "provider", "1.0 PROVIDER whatever");
+		assertEquals(version1pro, version2pro);
 	}
 
 	@Test
-	public void isGreater_whenVersionIsGreater_returnsTrue() {
-		assertThat(RexsStandardVersions.V1_2.isGreater(RexsStandardVersions.V1_0)).isTrue();
-		assertThat(RexsStandardVersions.V1_0.isGreater(RexsStandardVersions.V1_2)).isFalse();
+	public void equals_whenDifferentSchemaOrProvider_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("1.0", null, "1.0");
+		RexsVersion version2 = RexsVersion.create("1.1", null, "1.1");
+		RexsVersion version1pro = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2pro = RexsVersion.create("1.1", "provider", "1.1");
+		assertNotEquals(version1, version2);
+		assertNotEquals(version1pro, version2pro);
+		assertNotEquals(version1, version1pro);
+		assertNotEquals(version2, version2pro);
 	}
 
 	@Test
-	public void isLess_whenVersionIsLess_returnsTrue() {
-		assertThat(RexsStandardVersions.V1_0.isLess(RexsStandardVersions.V1_2)).isTrue();
-		assertThat(RexsStandardVersions.V1_2.isLess(RexsStandardVersions.V1_0)).isFalse();
+	public void equals_whenDifferentObject_thenNotEqual() {
+		RexsVersion version = RexsVersion.create("1.0", null, "1.0");
+		assertNotEquals(version, new Object());
 	}
 
 	@Test
-	public void isOneOf_whenVersionMatchesOneOfTheSpecifiedVersions_returnsTrue() {
-		assertThat(RexsStandardVersions.V1_1.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
-		assertThat(RexsStandardVersions.V1_2.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
-		assertThat(RexsStandardVersions.V1_3.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isTrue();
+	public void hashCode_whenSameSchemaAndProvider_thenReturnsSameHashCode() {
+		// without provider
+		RexsVersion version1 = RexsVersion.create("1.0", null, "1.0");
+		RexsVersion version2 = RexsVersion.create("1.0", null, "1.1");
+		assertEquals(version1.hashCode(), version2.hashCode());
+
+		// with provider
+		RexsVersion version1pro = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2pro = RexsVersion.create("1.0", "provider", "1.1");
+		assertEquals(version1pro.hashCode(), version2pro.hashCode());
 	}
 
 	@Test
-	public void isOneOf_whenVersionDoesNotMatchAnySpecifiedVersions_returnsFalse() {
-		assertThat(RexsStandardVersions.V1_4.isOneOf(RexsStandardVersions.V1_1, RexsStandardVersions.V1_2, RexsStandardVersions.V1_3)).isFalse();
+	public void hashCode_whenDifferentSchemaOrProvider_thenReturnsDifferentHashCode() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider1", "1.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider2", "1.0");
+		assertNotEquals(version1.hashCode(), version2.hashCode());
+	}
+
+	@Test
+	public void getNumericVersion_whenUnknownVersion_thenReturnsMinusOne() {
+		assertEquals(-1, RexsVersion.UNKNOWN.getNumericVersion());
+	}
+
+	@Test
+	public void getNumericVersion_whenDevVersion_thenReturnsMaxValue() {
+		assertEquals(Integer.MAX_VALUE, RexsVersion.DEV.getNumericVersion());
+	}
+
+	@Test
+	public void getNumericVersion_whenValidVersion_thenReturnsNumericValue() {
+		RexsVersion version = RexsVersion.create("1.0", "provider", "1.0");
+		assertEquals(10000, version.getNumericVersion());
+
+		version = RexsVersion.create("2.5", "provider", "2.5");
+		assertEquals(20500, version.getNumericVersion());
+	}
+
+	@Test
+	public void compareTo_whenVersionsAreEqual_thenReturnsZero() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.1");
+		assertEquals(0, version1.compareTo(version2));
+	}
+
+	@Test
+	public void compareTo_whenThisVersionIsLessThanOther_thenReturnsNegative() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		assertTrue(version1.compareTo(version2) < 0);
+	}
+
+	@Test
+	public void compareTo_whenThisVersionIsGreaterThanOther_thenReturnsPositive() {
+		RexsVersion version1 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.0");
+		assertTrue(version1.compareTo(version2) > 0);
+	}
+
+	@Test
+	public void isLessThan_whenThisVersionIsLessThanOther_thenReturnsTrue() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		assertTrue(version1.isLessThan(version2));
+	}
+
+	@Test
+	public void isLessThan_whenThisVersionIsNotLessThanOther_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.0");
+		assertFalse(version1.isLessThan(version2));
+	}
+
+	@Test
+	public void isLessThanOrEquivalentTo_whenThisVersionIsLessThanOrEqualToOther_thenReturnsTrue() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version3 = RexsVersion.create("1.0", "provider", "1.1");
+		assertTrue(version1.isLessThanOrEquivalentTo(version2));
+		assertTrue(version1.isLessThanOrEquivalentTo(version3));
+	}
+
+	@Test
+	public void isLessThanOrEquivalentTo_whenThisVersionIsNotLessThanOrEqualToOther_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.0");
+		assertFalse(version1.isLessThanOrEquivalentTo(version2));
+	}
+
+	@Test
+	public void isGreaterThan_whenThisVersionIsGreaterThanOther_thenReturnsTrue() {
+		RexsVersion version1 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.0");
+		assertTrue(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void isGreaterThan_whenThisVersionIsNotGreaterThanOther_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		assertFalse(version1.isGreaterThan(version2));
+	}
+
+	@Test
+	public void isGreaterThanOrEquivalentTo_whenThisVersionIsGreaterThanOrEqualToOther_thenReturnsTrue() {
+		RexsVersion version1 = RexsVersion.create("2.0", "provider", "2.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version3 = RexsVersion.create("2.0", "provider", "2.1");
+		assertTrue(version1.isGreaterThanOrEquivalentTo(version2));
+		assertTrue(version1.isGreaterThanOrEquivalentTo(version3));
+	}
+
+	@Test
+	public void isGreaterThanOrEquivalentTo_whenThisVersionIsNotGreaterThanOrEqualToOther_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		assertFalse(version1.isGreaterThanOrEquivalentTo(version2));
+	}
+
+	@Test
+	public void isEquivalentTo_whenVersionsAreEqual_thenReturnsTrue() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("1.0", "provider", "1.1");
+		assertTrue(version1.isEquivalentTo(version2));
+	}
+
+	@Test
+	public void isEquivalentTo_whenVersionsAreNotEqual_thenReturnsFalse() {
+		RexsVersion version1 = RexsVersion.create("1.0", "provider", "1.0");
+		RexsVersion version2 = RexsVersion.create("2.0", "provider", "2.0");
+		assertFalse(version1.isEquivalentTo(version2));
 	}
 }

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
@@ -70,8 +70,8 @@ public class ChangelogFileTest {
 	public void equals_equalObjects() {
 		assertThat(ChangelogFile.V1_0_TO_V1_1.equals(ChangelogFile.V1_0_TO_V1_1)).isTrue();
 
-		RexsVersion newFromVersion = RexsVersion.create("o.p", 1);
-		RexsVersion newToVersion = RexsVersion.create("p.q", 1);
+		RexsVersion newFromVersion = RexsVersion.create("41.1", null, "41.1");
+		RexsVersion newToVersion = RexsVersion.create("41.2", null, "41.2");
 		assertThat(ChangelogFile.create(newFromVersion, newToVersion)).isEqualTo(ChangelogFile.create(newFromVersion, newToVersion));
 	}
 
@@ -80,8 +80,8 @@ public class ChangelogFileTest {
 		assertThat(ChangelogFile.V1_0_TO_V1_1).isNotEqualTo(ChangelogFile.V1_1_TO_V1_2);
 		assertThat(ChangelogFile.V1_1_TO_V1_2).isNotEqualTo("test");
 
-		RexsVersion newVersion1 = RexsVersion.create("p.q", 1);
-		RexsVersion newVersion2 = RexsVersion.create("q.r", 1);
+		RexsVersion newVersion1 = RexsVersion.create("41.1", null, "41.1");
+		RexsVersion newVersion2 = RexsVersion.create("41.2", null, "41.2");
 		assertThat(ChangelogFile.create(newVersion1, newVersion2)).isNotEqualTo(ChangelogFile.create(newVersion2, newVersion1));
 		assertThat(ChangelogFile.create(newVersion2, newVersion1)).isNotEqualTo(ChangelogFile.create(newVersion1, newVersion2));
 	}

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
@@ -65,8 +65,8 @@ public class ChangelogResolverTest {
 		List<ChangelogFile> rexsStandardChangelogFiles = Stream.of(ChangelogFile.V1_0_TO_V1_1, ChangelogFile.V1_1_TO_V1_2).collect(Collectors.toList());
 		for (ChangelogFile changelogFile : rexsStandardChangelogFiles) {
 			RexsChangelog rexsChangelog = ChangelogResolver.getInstance().resolve(changelogFile);
-			assertThat(rexsChangelog.getFromVersion()).isEqualTo(changelogFile.getFromVersion().getName());
-			assertThat(rexsChangelog.getToVersion()).isEqualTo(changelogFile.getToVersion().getName());
+			assertThat(rexsChangelog.getFromVersion()).isEqualTo(changelogFile.getFromVersion().getModelVersion());
+			assertThat(rexsChangelog.getToVersion()).isEqualTo(changelogFile.getToVersion().getModelVersion());
 
 			int countChangelogChanges = 0;
 			countChangelogChanges += rexsChangelog.getComponentChanges() != null ? rexsChangelog.getComponentChanges().size() : 0;

--- a/cli/src/main/java/info/rexs/cli/common/RexsVersionConverter.java
+++ b/cli/src/main/java/info/rexs/cli/common/RexsVersionConverter.java
@@ -8,6 +8,6 @@ public class RexsVersionConverter implements IStringConverter<RexsVersion> {
 
 	@Override
 	public RexsVersion convert(String value) {
-		return RexsVersion.findByName(value);
+		return RexsVersion.findByModelVersion(value);
 	}
 }

--- a/cli/src/main/java/info/rexs/cli/common/RexsVersionParameterValidator.java
+++ b/cli/src/main/java/info/rexs/cli/common/RexsVersionParameterValidator.java
@@ -4,15 +4,14 @@ import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.ParameterException;
 
 import info.rexs.schema.constants.RexsVersion;
-import info.rexs.schema.constants.standard.RexsStandardVersions;
 
 public class RexsVersionParameterValidator implements IParameterValidator {
 
 	@Override
 	public void validate(String name, String value) throws ParameterException {
-		RexsVersion version = RexsVersion.findByName(value);
+		RexsVersion version = RexsVersion.findByModelVersion(value);
 
-		if (version == null || version.isOneOf(RexsStandardVersions.UNKNOWN))
+		if (version == null || version.equals(RexsVersion.UNKNOWN))
 			throw new ParameterException(String.format("Unknown REXS version '%s'", value));
 	}
 }

--- a/cli/src/main/java/info/rexs/cli/convert/ConvertCommandServiceImpl.java
+++ b/cli/src/main/java/info/rexs/cli/convert/ConvertCommandServiceImpl.java
@@ -44,8 +44,8 @@ public class ConvertCommandServiceImpl {
 		 */
 		RexsVersion targetVersion = options.getTargetVersion() != null ? options.getTargetVersion() : rexsModel.getVersion();
 
-		if (targetVersion.isLess(rexsModel.getVersion())) {
-			console.println(String.format("The target version is smaller than the version of the REXS model (%s < %s).", targetVersion.getName(), rexsModel.getVersion().getName()));
+		if (targetVersion.isLessThan(rexsModel.getVersion())) {
+			console.println(String.format("The target version is smaller than the version of the REXS model (%s < %s).", targetVersion.getModelVersion(), rexsModel.getVersion().getModelVersion()));
 			return;
 		}
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,13 @@
 					<version>3.11.1</version>
 					<configuration>
 						<quiet>true</quiet>
+						<tags>
+							<tag>
+								<name>apiNote</name>
+								<placement>a</placement>
+								<head>API Note:</head>
+							</tag>
+						</tags>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
This pull request resolves #133 using previous work from [DJK/versioning5](https://github.com/fva-net/rexs-api-java/tree/DJK/versioning5).