### PR TITLE
Code cleaning

### DIFF
--- a/api/src/main/java/info/rexs/io/ByteArrayResource.java
+++ b/api/src/main/java/info/rexs/io/ByteArrayResource.java
@@ -16,7 +16,6 @@
 package info.rexs.io;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 public class ByteArrayResource implements Resource {
@@ -31,7 +30,7 @@ public class ByteArrayResource implements Resource {
 	}
 
 	@Override
-	public InputStream openInputStream() throws IOException {
+	public InputStream openInputStream() {
 		return new ByteArrayInputStream(this.byteArray);
 	}
 
@@ -41,7 +40,7 @@ public class ByteArrayResource implements Resource {
 	}
 
 	@Override
-	public long getContentLength() throws IOException {
+	public long getContentLength() {
 		return this.byteArray.length;
 	}
 

--- a/api/src/main/java/info/rexs/io/RexsIoFormat.java
+++ b/api/src/main/java/info/rexs/io/RexsIoFormat.java
@@ -62,7 +62,7 @@ public enum RexsIoFormat {
 		}
 	};
 
-	private RexsIoFormat(String... endings) {
+	RexsIoFormat(String... endings) {
 		this.endings = endings;
 	}
 

--- a/api/src/main/java/info/rexs/io/json/model/Accumulation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Accumulation.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -89,7 +90,7 @@ public class Accumulation {
         if (!(other instanceof Accumulation rhs)) {
             return false;
         }
-		return (((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))));
+		return ((Objects.equals(this.components, rhs.components)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Accumulation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Accumulation.java
@@ -86,7 +86,7 @@ public class Accumulation {
         if (other == this) {
             return true;
         }
-        if ((other instanceof Accumulation) == false) {
+        if (!(other instanceof Accumulation)) {
             return false;
         }
         Accumulation rhs = ((Accumulation) other);

--- a/api/src/main/java/info/rexs/io/json/model/Accumulation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Accumulation.java
@@ -86,11 +86,10 @@ public class Accumulation {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Accumulation)) {
+        if (!(other instanceof Accumulation rhs)) {
             return false;
         }
-        Accumulation rhs = ((Accumulation) other);
-        return (((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))));
+		return (((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Accumulation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Accumulation.java
@@ -1,8 +1,10 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,9 +19,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class Accumulation {
 
     @JsonProperty("components")
-    private List<Component> components = new ArrayList<Component>();
+    private List<Component> components = new ArrayList<>();
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("components")
     public List<Component> getComponents() {

--- a/api/src/main/java/info/rexs/io/json/model/Component.java
+++ b/api/src/main/java/info/rexs/io/json/model/Component.java
@@ -156,7 +156,7 @@ public class Component {
         if (other == this) {
             return true;
         }
-        if ((other instanceof Component) == false) {
+        if (!(other instanceof Component)) {
             return false;
         }
         Component rhs = ((Component) other);

--- a/api/src/main/java/info/rexs/io/json/model/Component.java
+++ b/api/src/main/java/info/rexs/io/json/model/Component.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -159,7 +160,7 @@ public class Component {
         if (!(other instanceof Component rhs)) {
             return false;
         }
-		return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.attributes == rhs.attributes)||((this.attributes!= null)&&this.attributes.equals(rhs.attributes))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))));
+		return (((((Objects.equals(this.name, rhs.name))&&(Objects.equals(this.attributes, rhs.attributes)))&&(Objects.equals(this.id, rhs.id)))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.type, rhs.type)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Component.java
+++ b/api/src/main/java/info/rexs/io/json/model/Component.java
@@ -1,15 +1,16 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import info.rexs.io.json.model.attributes.Attribute;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -28,9 +29,9 @@ public class Component {
     @JsonProperty("name")
     private String name;
     @JsonProperty("attributes")
-    private List<Attribute> attributes = new ArrayList<Attribute>();
+    private List<Attribute> attributes = new ArrayList<>();
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public Integer getId() {

--- a/api/src/main/java/info/rexs/io/json/model/Component.java
+++ b/api/src/main/java/info/rexs/io/json/model/Component.java
@@ -156,11 +156,10 @@ public class Component {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Component)) {
+        if (!(other instanceof Component rhs)) {
             return false;
         }
-        Component rhs = ((Component) other);
-        return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.attributes == rhs.attributes)||((this.attributes!= null)&&this.attributes.equals(rhs.attributes))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))));
+		return ((((((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name)))&&((this.attributes == rhs.attributes)||((this.attributes!= null)&&this.attributes.equals(rhs.attributes))))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
@@ -107,11 +107,10 @@ public class FloatingPointArrayCoded {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointArrayCoded)) {
+        if (!(other instanceof FloatingPointArrayCoded rhs)) {
             return false;
         }
-        FloatingPointArrayCoded rhs = ((FloatingPointArrayCoded) other);
-        return ((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))));
+		return ((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
@@ -107,7 +107,7 @@ public class FloatingPointArrayCoded {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointArrayCoded) == false) {
+        if (!(other instanceof FloatingPointArrayCoded)) {
             return false;
         }
         FloatingPointArrayCoded rhs = ((FloatingPointArrayCoded) other);

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
@@ -2,6 +2,7 @@ package info.rexs.io.json.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -110,7 +111,7 @@ public class FloatingPointArrayCoded {
         if (!(other instanceof FloatingPointArrayCoded rhs)) {
             return false;
         }
-		return ((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))));
+		return (((Objects.equals(this.code, rhs.code))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.value, rhs.value)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointArrayCoded.java
@@ -1,6 +1,8 @@
 package info.rexs.io.json.model;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -20,7 +22,7 @@ public class FloatingPointArrayCoded {
     @JsonProperty("value")
     private String value;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("code")
     public String getCode() {

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
@@ -1,6 +1,8 @@
 package info.rexs.io.json.model;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,7 +28,7 @@ public class FloatingPointMatrixCoded {
     @JsonProperty("value")
     private String value;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("code")
     public String getCode() {

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
@@ -153,7 +153,7 @@ public class FloatingPointMatrixCoded {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointMatrixCoded) == false) {
+        if (!(other instanceof FloatingPointMatrixCoded)) {
             return false;
         }
         FloatingPointMatrixCoded rhs = ((FloatingPointMatrixCoded) other);

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
@@ -2,6 +2,7 @@ package info.rexs.io.json.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -156,7 +157,7 @@ public class FloatingPointMatrixCoded {
         if (!(other instanceof FloatingPointMatrixCoded rhs)) {
             return false;
         }
-		return ((((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.rows == rhs.rows)||((this.rows!= null)&&this.rows.equals(rhs.rows))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))))&&((this.columns == rhs.columns)||((this.columns!= null)&&this.columns.equals(rhs.columns))));
+		return (((((Objects.equals(this.code, rhs.code))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.rows, rhs.rows)))&&(Objects.equals(this.value, rhs.value)))&&(Objects.equals(this.columns, rhs.columns)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
+++ b/api/src/main/java/info/rexs/io/json/model/FloatingPointMatrixCoded.java
@@ -153,11 +153,10 @@ public class FloatingPointMatrixCoded {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointMatrixCoded)) {
+        if (!(other instanceof FloatingPointMatrixCoded rhs)) {
             return false;
         }
-        FloatingPointMatrixCoded rhs = ((FloatingPointMatrixCoded) other);
-        return ((((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.rows == rhs.rows)||((this.rows!= null)&&this.rows.equals(rhs.rows))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))))&&((this.columns == rhs.columns)||((this.columns!= null)&&this.columns.equals(rhs.columns))));
+		return ((((((this.code == rhs.code)||((this.code!= null)&&this.code.equals(rhs.code)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.rows == rhs.rows)||((this.rows!= null)&&this.rows.equals(rhs.rows))))&&((this.value == rhs.value)||((this.value!= null)&&this.value.equals(rhs.value))))&&((this.columns == rhs.columns)||((this.columns!= null)&&this.columns.equals(rhs.columns))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/JSONModel.java
+++ b/api/src/main/java/info/rexs/io/json/model/JSONModel.java
@@ -84,11 +84,10 @@ public class JSONModel {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof JSONModel)) {
+        if (!(other instanceof JSONModel rhs)) {
             return false;
         }
-        JSONModel rhs = ((JSONModel) other);
-        return (((this.model == rhs.model)||((this.model!= null)&&this.model.equals(rhs.model)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
+		return (((this.model == rhs.model)||((this.model!= null)&&this.model.equals(rhs.model)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/JSONModel.java
+++ b/api/src/main/java/info/rexs/io/json/model/JSONModel.java
@@ -84,7 +84,7 @@ public class JSONModel {
         if (other == this) {
             return true;
         }
-        if ((other instanceof JSONModel) == false) {
+        if (!(other instanceof JSONModel)) {
             return false;
         }
         JSONModel rhs = ((JSONModel) other);

--- a/api/src/main/java/info/rexs/io/json/model/JSONModel.java
+++ b/api/src/main/java/info/rexs/io/json/model/JSONModel.java
@@ -1,6 +1,8 @@
 package info.rexs.io.json.model;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,7 +19,7 @@ public class JSONModel {
     @JsonProperty("model")
     private Model model;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("model")
     public Model getModel() {

--- a/api/src/main/java/info/rexs/io/json/model/JSONModel.java
+++ b/api/src/main/java/info/rexs/io/json/model/JSONModel.java
@@ -2,6 +2,7 @@ package info.rexs.io.json.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -87,7 +88,7 @@ public class JSONModel {
         if (!(other instanceof JSONModel rhs)) {
             return false;
         }
-		return (((this.model == rhs.model)||((this.model!= null)&&this.model.equals(rhs.model)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
+		return ((Objects.equals(this.model, rhs.model))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/LoadCase.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadCase.java
@@ -109,11 +109,10 @@ public class LoadCase {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof LoadCase)) {
+        if (!(other instanceof LoadCase rhs)) {
             return false;
         }
-        LoadCase rhs = ((LoadCase) other);
-        return ((((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
+		return ((((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/LoadCase.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadCase.java
@@ -1,8 +1,10 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -20,9 +22,9 @@ public class LoadCase {
     @JsonProperty("id")
     private Integer id;
     @JsonProperty("components")
-    private List<Component> components = new ArrayList<Component>();
+    private List<Component> components = new ArrayList<>();
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public Integer getId() {

--- a/api/src/main/java/info/rexs/io/json/model/LoadCase.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadCase.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -112,7 +113,7 @@ public class LoadCase {
         if (!(other instanceof LoadCase rhs)) {
             return false;
         }
-		return ((((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components)))&&((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))));
+		return (((Objects.equals(this.components, rhs.components))&&(Objects.equals(this.id, rhs.id)))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/LoadCase.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadCase.java
@@ -109,7 +109,7 @@ public class LoadCase {
         if (other == this) {
             return true;
         }
-        if ((other instanceof LoadCase) == false) {
+        if (!(other instanceof LoadCase)) {
             return false;
         }
         LoadCase rhs = ((LoadCase) other);

--- a/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -135,7 +136,7 @@ public class LoadSpectrum {
         if (!(other instanceof LoadSpectrum rhs)) {
             return false;
         }
-		return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.loadCases == rhs.loadCases)||((this.loadCases!= null)&&this.loadCases.equals(rhs.loadCases))))&&((this.accumulation == rhs.accumulation)||((this.accumulation!= null)&&this.accumulation.equals(rhs.accumulation))));
+		return ((((Objects.equals(this.id, rhs.id))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.loadCases, rhs.loadCases)))&&(Objects.equals(this.accumulation, rhs.accumulation)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
@@ -132,7 +132,7 @@ public class LoadSpectrum {
         if (other == this) {
             return true;
         }
-        if ((other instanceof LoadSpectrum) == false) {
+        if (!(other instanceof LoadSpectrum)) {
             return false;
         }
         LoadSpectrum rhs = ((LoadSpectrum) other);

--- a/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
@@ -132,11 +132,10 @@ public class LoadSpectrum {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof LoadSpectrum)) {
+        if (!(other instanceof LoadSpectrum rhs)) {
             return false;
         }
-        LoadSpectrum rhs = ((LoadSpectrum) other);
-        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.loadCases == rhs.loadCases)||((this.loadCases!= null)&&this.loadCases.equals(rhs.loadCases))))&&((this.accumulation == rhs.accumulation)||((this.accumulation!= null)&&this.accumulation.equals(rhs.accumulation))));
+		return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.loadCases == rhs.loadCases)||((this.loadCases!= null)&&this.loadCases.equals(rhs.loadCases))))&&((this.accumulation == rhs.accumulation)||((this.accumulation!= null)&&this.accumulation.equals(rhs.accumulation))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
+++ b/api/src/main/java/info/rexs/io/json/model/LoadSpectrum.java
@@ -1,8 +1,10 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -21,11 +23,11 @@ public class LoadSpectrum {
     @JsonProperty("id")
     private Integer id;
     @JsonProperty("load_cases")
-    private List<LoadCase> loadCases = new ArrayList<LoadCase>();
+    private List<LoadCase> loadCases = new ArrayList<>();
     @JsonProperty("accumulation")
     private Accumulation accumulation;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public Integer getId() {

--- a/api/src/main/java/info/rexs/io/json/model/Model.java
+++ b/api/src/main/java/info/rexs/io/json/model/Model.java
@@ -247,7 +247,7 @@ public class Model {
         if (other == this) {
             return true;
         }
-        if ((other instanceof Model) == false) {
+        if (!(other instanceof Model)) {
             return false;
         }
         Model rhs = ((Model) other);

--- a/api/src/main/java/info/rexs/io/json/model/Model.java
+++ b/api/src/main/java/info/rexs/io/json/model/Model.java
@@ -247,11 +247,10 @@ public class Model {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Model)) {
+        if (!(other instanceof Model rhs)) {
             return false;
         }
-        Model rhs = ((Model) other);
-        return ((((((((((this.applicationVersion == rhs.applicationVersion)||((this.applicationVersion!= null)&&this.applicationVersion.equals(rhs.applicationVersion)))&&((this.date == rhs.date)||((this.date!= null)&&this.date.equals(rhs.date))))&&((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))))&&((this.applicationLanguage == rhs.applicationLanguage)||((this.applicationLanguage!= null)&&this.applicationLanguage.equals(rhs.applicationLanguage))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.applicationId == rhs.applicationId)||((this.applicationId!= null)&&this.applicationId.equals(rhs.applicationId))))&&((this.relations == rhs.relations)||((this.relations!= null)&&this.relations.equals(rhs.relations))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.loadSpectrum == rhs.loadSpectrum)||((this.loadSpectrum!= null)&&this.loadSpectrum.equals(rhs.loadSpectrum))));
+		return ((((((((((this.applicationVersion == rhs.applicationVersion)||((this.applicationVersion!= null)&&this.applicationVersion.equals(rhs.applicationVersion)))&&((this.date == rhs.date)||((this.date!= null)&&this.date.equals(rhs.date))))&&((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))))&&((this.applicationLanguage == rhs.applicationLanguage)||((this.applicationLanguage!= null)&&this.applicationLanguage.equals(rhs.applicationLanguage))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.applicationId == rhs.applicationId)||((this.applicationId!= null)&&this.applicationId.equals(rhs.applicationId))))&&((this.relations == rhs.relations)||((this.relations!= null)&&this.relations.equals(rhs.relations))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.loadSpectrum == rhs.loadSpectrum)||((this.loadSpectrum!= null)&&this.loadSpectrum.equals(rhs.loadSpectrum))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Model.java
+++ b/api/src/main/java/info/rexs/io/json/model/Model.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -250,7 +251,7 @@ public class Model {
         if (!(other instanceof Model rhs)) {
             return false;
         }
-		return ((((((((((this.applicationVersion == rhs.applicationVersion)||((this.applicationVersion!= null)&&this.applicationVersion.equals(rhs.applicationVersion)))&&((this.date == rhs.date)||((this.date!= null)&&this.date.equals(rhs.date))))&&((this.components == rhs.components)||((this.components!= null)&&this.components.equals(rhs.components))))&&((this.applicationLanguage == rhs.applicationLanguage)||((this.applicationLanguage!= null)&&this.applicationLanguage.equals(rhs.applicationLanguage))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.applicationId == rhs.applicationId)||((this.applicationId!= null)&&this.applicationId.equals(rhs.applicationId))))&&((this.relations == rhs.relations)||((this.relations!= null)&&this.relations.equals(rhs.relations))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.loadSpectrum == rhs.loadSpectrum)||((this.loadSpectrum!= null)&&this.loadSpectrum.equals(rhs.loadSpectrum))));
+		return (((((((((Objects.equals(this.applicationVersion, rhs.applicationVersion))&&(Objects.equals(this.date, rhs.date)))&&(Objects.equals(this.components, rhs.components)))&&(Objects.equals(this.applicationLanguage, rhs.applicationLanguage)))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.applicationId, rhs.applicationId)))&&(Objects.equals(this.relations, rhs.relations)))&&(Objects.equals(this.version, rhs.version)))&&(Objects.equals(this.loadSpectrum, rhs.loadSpectrum)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Model.java
+++ b/api/src/main/java/info/rexs/io/json/model/Model.java
@@ -1,8 +1,10 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,13 +36,13 @@ public class Model {
     @JsonProperty("applicationLanguage")
     private String applicationLanguage;
     @JsonProperty("relations")
-    private List<Relation> relations = new ArrayList<Relation>();
+    private List<Relation> relations = new ArrayList<>();
     @JsonProperty("components")
-    private List<Component> components = new ArrayList<Component>();
+    private List<Component> components = new ArrayList<>();
     @JsonProperty("load_spectrum")
     private LoadSpectrum loadSpectrum;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("version")
     public String getVersion() {

--- a/api/src/main/java/info/rexs/io/json/model/Ref.java
+++ b/api/src/main/java/info/rexs/io/json/model/Ref.java
@@ -130,7 +130,7 @@ public class Ref {
         if (other == this) {
             return true;
         }
-        if ((other instanceof Ref) == false) {
+        if (!(other instanceof Ref)) {
             return false;
         }
         Ref rhs = ((Ref) other);

--- a/api/src/main/java/info/rexs/io/json/model/Ref.java
+++ b/api/src/main/java/info/rexs/io/json/model/Ref.java
@@ -2,6 +2,7 @@ package info.rexs.io.json.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -133,7 +134,7 @@ public class Ref {
         if (!(other instanceof Ref rhs)) {
             return false;
         }
-		return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.role == rhs.role)||((this.role!= null)&&this.role.equals(rhs.role))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.hint == rhs.hint)||((this.hint!= null)&&this.hint.equals(rhs.hint))));
+		return ((((Objects.equals(this.id, rhs.id))&&(Objects.equals(this.role, rhs.role)))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.hint, rhs.hint)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Ref.java
+++ b/api/src/main/java/info/rexs/io/json/model/Ref.java
@@ -130,11 +130,10 @@ public class Ref {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Ref)) {
+        if (!(other instanceof Ref rhs)) {
             return false;
         }
-        Ref rhs = ((Ref) other);
-        return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.role == rhs.role)||((this.role!= null)&&this.role.equals(rhs.role))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.hint == rhs.hint)||((this.hint!= null)&&this.hint.equals(rhs.hint))));
+		return (((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.role == rhs.role)||((this.role!= null)&&this.role.equals(rhs.role))))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.hint == rhs.hint)||((this.hint!= null)&&this.hint.equals(rhs.hint))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Ref.java
+++ b/api/src/main/java/info/rexs/io/json/model/Ref.java
@@ -1,6 +1,8 @@
 package info.rexs.io.json.model;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -23,7 +25,7 @@ public class Ref {
     @JsonProperty("hint")
     private String hint;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public Integer getId() {

--- a/api/src/main/java/info/rexs/io/json/model/Relation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Relation.java
@@ -1,8 +1,10 @@
 package info.rexs.io.json.model;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -26,9 +28,9 @@ public class Relation {
     @JsonProperty("order")
     private Integer order;
     @JsonProperty("refs")
-    private List<Ref> refs = new ArrayList<Ref>();
+    private List<Ref> refs = new ArrayList<>();
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public Integer getId() {

--- a/api/src/main/java/info/rexs/io/json/model/Relation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Relation.java
@@ -155,11 +155,10 @@ public class Relation {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof Relation)) {
+        if (!(other instanceof Relation rhs)) {
             return false;
         }
-        Relation rhs = ((Relation) other);
-        return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.refs == rhs.refs)||((this.refs!= null)&&this.refs.equals(rhs.refs))))&&((this.order == rhs.order)||((this.order!= null)&&this.order.equals(rhs.order))));
+		return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.refs == rhs.refs)||((this.refs!= null)&&this.refs.equals(rhs.refs))))&&((this.order == rhs.order)||((this.order!= null)&&this.order.equals(rhs.order))));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/Relation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Relation.java
@@ -155,7 +155,7 @@ public class Relation {
         if (other == this) {
             return true;
         }
-        if ((other instanceof Relation) == false) {
+        if (!(other instanceof Relation)) {
             return false;
         }
         Relation rhs = ((Relation) other);

--- a/api/src/main/java/info/rexs/io/json/model/Relation.java
+++ b/api/src/main/java/info/rexs/io/json/model/Relation.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -158,7 +159,7 @@ public class Relation {
         if (!(other instanceof Relation rhs)) {
             return false;
         }
-		return ((((((this.id == rhs.id)||((this.id!= null)&&this.id.equals(rhs.id)))&&((this.additionalProperties == rhs.additionalProperties)||((this.additionalProperties!= null)&&this.additionalProperties.equals(rhs.additionalProperties))))&&((this.type == rhs.type)||((this.type!= null)&&this.type.equals(rhs.type))))&&((this.refs == rhs.refs)||((this.refs!= null)&&this.refs.equals(rhs.refs))))&&((this.order == rhs.order)||((this.order!= null)&&this.order.equals(rhs.order))));
+		return (((((Objects.equals(this.id, rhs.id))&&(Objects.equals(this.additionalProperties, rhs.additionalProperties)))&&(Objects.equals(this.type, rhs.type)))&&(Objects.equals(this.refs, rhs.refs)))&&(Objects.equals(this.order, rhs.order)));
     }
 
 }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
@@ -63,7 +63,7 @@ public class ArrayOfIntegerArraysAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof ArrayOfIntegerArraysAttribute) == false) {
+        if (!(other instanceof ArrayOfIntegerArraysAttribute)) {
             return false;
         }
         ArrayOfIntegerArraysAttribute rhs = ((ArrayOfIntegerArraysAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class ArrayOfIntegerArraysAttribute extends Attribute {
 
     @JsonProperty("array_of_integer_arrays")
-    private List<List<Integer>> arrayOfIntegerArrays = new ArrayList<List<Integer>>();
+    private List<List<Integer>> arrayOfIntegerArrays = new ArrayList<>();
 
     @JsonProperty("array_of_integer_arrays")
     public List<List<Integer>> getArrayOfIntegerArrays() {
@@ -67,9 +67,9 @@ public class ArrayOfIntegerArraysAttribute extends Attribute {
             return false;
         }
         ArrayOfIntegerArraysAttribute rhs = ((ArrayOfIntegerArraysAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.arrayOfIntegerArrays.containsAll(rhs.getArrayOfIntegerArrays()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.arrayOfIntegerArrays.containsAll(rhs.getArrayOfIntegerArrays())
             && rhs.getArrayOfIntegerArrays().containsAll(this.arrayOfIntegerArrays);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/ArrayOfIntegerArraysAttribute.java
@@ -63,11 +63,10 @@ public class ArrayOfIntegerArraysAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof ArrayOfIntegerArraysAttribute)) {
+        if (!(other instanceof ArrayOfIntegerArraysAttribute rhs)) {
             return false;
         }
-        ArrayOfIntegerArraysAttribute rhs = ((ArrayOfIntegerArraysAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.arrayOfIntegerArrays.containsAll(rhs.getArrayOfIntegerArrays())
             && rhs.getArrayOfIntegerArrays().containsAll(this.arrayOfIntegerArrays);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/Attribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/Attribute.java
@@ -3,6 +3,7 @@ package info.rexs.io.json.model.attributes;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,9 +35,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = FloatingPointMatrixAttribute.class, name = "FloatingPointMatrixAttribute"),
     @JsonSubTypes.Type(value = IntegerMatrixAttribute.class, name = "IntegerMatrixAttribute"),
     @JsonSubTypes.Type(value = StringMatrixAttribute.class, name = "StringMatrixAttribute"),
-    
+
     @JsonSubTypes.Type(value = ArrayOfIntegerArraysAttribute.class, name = "ArrayOfIntegerArraysAttribute"),
-    
+
 
     @JsonSubTypes.Type(value = FileReferenceAttribute.class, name = "FileReferenceAttribute"),
     @JsonSubTypes.Type(value = ReferenceComponentAttribute.class, name = "ReferenceComponentAttribute")
@@ -53,9 +54,9 @@ public abstract class Attribute {
 
     @JsonProperty("unit")
     protected String unit;
-    
+
     @JsonIgnore
-    protected Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    protected Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("id")
     public String getId() {

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
@@ -65,7 +65,7 @@ public class BooleanArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof BooleanArrayAttribute) == false) {
+        if (!(other instanceof BooleanArrayAttribute)) {
             return false;
         }
         BooleanArrayAttribute rhs = ((BooleanArrayAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
@@ -65,11 +65,10 @@ public class BooleanArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof BooleanArrayAttribute)) {
+        if (!(other instanceof BooleanArrayAttribute rhs)) {
             return false;
         }
-        BooleanArrayAttribute rhs = ((BooleanArrayAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.booleanArray.containsAll(rhs.getBooleanArray())
             && rhs.getBooleanArray().containsAll(this.booleanArray);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanArrayAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class BooleanArrayAttribute extends Attribute {
 
     @JsonProperty("boolean_array")
-    private List<Boolean> booleanArray = new ArrayList<Boolean>();
+    private List<Boolean> booleanArray = new ArrayList<>();
 
     @JsonProperty("boolean_array")
     public List<Boolean> getBooleanArray() {
@@ -69,9 +69,9 @@ public class BooleanArrayAttribute extends Attribute {
             return false;
         }
         BooleanArrayAttribute rhs = ((BooleanArrayAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.booleanArray.containsAll(rhs.getBooleanArray()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.booleanArray.containsAll(rhs.getBooleanArray())
             && rhs.getBooleanArray().containsAll(this.booleanArray);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanAttribute.java
@@ -62,11 +62,10 @@ public class BooleanAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof BooleanAttribute)) {
+        if (!(other instanceof BooleanAttribute rhs)) {
             return false;
         }
-        BooleanAttribute rhs = ((BooleanAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this._boolean.equals(rhs.getBoolean());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanAttribute.java
@@ -16,7 +16,7 @@ public class BooleanAttribute extends Attribute {
 
     @JsonProperty("boolean")
     private Boolean _boolean;
-    
+
     @JsonProperty("boolean")
     public Boolean getBoolean() {
         return _boolean;
@@ -62,12 +62,12 @@ public class BooleanAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof BooleanAttribute) == false) {
+        if (!(other instanceof BooleanAttribute)) {
             return false;
         }
         BooleanAttribute rhs = ((BooleanAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this._boolean.equals(rhs.getBoolean());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,9 +16,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 public class BooleanMatrixAttribute extends Attribute {
 
-    
+
     @JsonProperty("boolean_matrix")
-    private List<List<Boolean>> booleanMatrix = new ArrayList<List<Boolean>>();
+    private List<List<Boolean>> booleanMatrix = new ArrayList<>();
 
     @JsonProperty("boolean_matrix")
     public List<List<Boolean>> getBooleanMatrix() {
@@ -70,9 +70,9 @@ public class BooleanMatrixAttribute extends Attribute {
             return false;
         }
         BooleanMatrixAttribute rhs = ((BooleanMatrixAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.booleanMatrix.containsAll(rhs.getBooleanMatrix()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.booleanMatrix.containsAll(rhs.getBooleanMatrix())
             && rhs.getBooleanMatrix().containsAll(this.booleanMatrix);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
@@ -66,7 +66,7 @@ public class BooleanMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof BooleanMatrixAttribute) == false) {
+        if (!(other instanceof BooleanMatrixAttribute)) {
             return false;
         }
         BooleanMatrixAttribute rhs = ((BooleanMatrixAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/BooleanMatrixAttribute.java
@@ -66,11 +66,10 @@ public class BooleanMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof BooleanMatrixAttribute)) {
+        if (!(other instanceof BooleanMatrixAttribute rhs)) {
             return false;
         }
-        BooleanMatrixAttribute rhs = ((BooleanMatrixAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.booleanMatrix.containsAll(rhs.getBooleanMatrix())
             && rhs.getBooleanMatrix().containsAll(this.booleanMatrix);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/DateTimeAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/DateTimeAttribute.java
@@ -19,7 +19,7 @@ public class DateTimeAttribute extends Attribute {
 
     @JsonProperty("date_time")
     private String date_time;
-    
+
     @JsonProperty("date_time")
     public String getTime() {
         return date_time;
@@ -58,9 +58,8 @@ public class DateTimeAttribute extends Attribute {
     	if (other == this) {
     		return true;
     	}
-    	if (other instanceof DateTimeAttribute) {
-    		DateTimeAttribute rhs = ((DateTimeAttribute) other);
-    		return Objects.equals(this.id, rhs.id) && Objects.equals(this.unit, rhs.unit) && Objects.equals(this.date_time, rhs.date_time);
+    	if (other instanceof DateTimeAttribute rhs) {
+			return Objects.equals(this.id, rhs.id) && Objects.equals(this.unit, rhs.unit) && Objects.equals(this.date_time, rhs.date_time);
     	}
     	return false;
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
@@ -65,11 +65,10 @@ public class EnumArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof EnumArrayAttribute)) {
+        if (!(other instanceof EnumArrayAttribute rhs)) {
             return false;
         }
-        EnumArrayAttribute rhs = ((EnumArrayAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.enumArray.containsAll(rhs.getEnumArray())
             && rhs.getEnumArray().containsAll(this.enumArray);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
@@ -65,7 +65,7 @@ public class EnumArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof EnumArrayAttribute) == false) {
+        if (!(other instanceof EnumArrayAttribute)) {
             return false;
         }
         EnumArrayAttribute rhs = ((EnumArrayAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/EnumArrayAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class EnumArrayAttribute extends Attribute {
 
     @JsonProperty("enum_array")
-    private List<String> enumArray = new ArrayList<String>();
+    private List<String> enumArray = new ArrayList<>();
 
     @JsonProperty("enum_array")
     public List<String> getEnumArray() {
@@ -69,9 +69,9 @@ public class EnumArrayAttribute extends Attribute {
             return false;
         }
         EnumArrayAttribute rhs = ((EnumArrayAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.enumArray.containsAll(rhs.getEnumArray()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.enumArray.containsAll(rhs.getEnumArray())
             && rhs.getEnumArray().containsAll(this.enumArray);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/EnumAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/EnumAttribute.java
@@ -16,7 +16,7 @@ public class EnumAttribute extends Attribute {
 
     @JsonProperty("enum")
     private String _enum;
-    
+
     @JsonProperty("enum")
     public String getEnum() {
         return _enum;
@@ -62,12 +62,12 @@ public class EnumAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof StringAttribute) == false) {
+        if (!(other instanceof StringAttribute)) {
             return false;
         }
         EnumAttribute rhs = ((EnumAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this._enum.equals(rhs.getEnum());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FileReferenceAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FileReferenceAttribute.java
@@ -62,11 +62,10 @@ public class FileReferenceAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FileReferenceAttribute)) {
+        if (!(other instanceof FileReferenceAttribute rhs)) {
             return false;
         }
-        FileReferenceAttribute rhs = ((FileReferenceAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.fileReference.equals(rhs.getFileReference());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FileReferenceAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FileReferenceAttribute.java
@@ -16,7 +16,7 @@ public class FileReferenceAttribute extends Attribute {
 
     @JsonProperty("file_reference")
     private String fileReference;
-    
+
     @JsonProperty("file_reference")
     public String getFileReference() {
         return fileReference;
@@ -62,12 +62,12 @@ public class FileReferenceAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FileReferenceAttribute) == false) {
+        if (!(other instanceof FileReferenceAttribute)) {
             return false;
         }
         FileReferenceAttribute rhs = ((FileReferenceAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.fileReference.equals(rhs.getFileReference());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
@@ -64,7 +64,7 @@ public class FloatingPointArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointArrayAttribute) == false) {
+        if (!(other instanceof FloatingPointArrayAttribute)) {
             return false;
         }
         FloatingPointArrayAttribute rhs = ((FloatingPointArrayAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class FloatingPointArrayAttribute extends Attribute {
 
     @JsonProperty("floating_point_array")
-    private List<Double> floatingPointArray = new ArrayList<Double>();
+    private List<Double> floatingPointArray = new ArrayList<>();
 
     @JsonProperty("floating_point_array")
     public List<Double> getFloatingPointArray() {
@@ -68,9 +68,9 @@ public class FloatingPointArrayAttribute extends Attribute {
             return false;
         }
         FloatingPointArrayAttribute rhs = ((FloatingPointArrayAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.floatingPointArray.containsAll(rhs.getFloatingPointArray()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.floatingPointArray.containsAll(rhs.getFloatingPointArray())
             && rhs.getFloatingPointArray().containsAll(this.floatingPointArray);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayAttribute.java
@@ -64,11 +64,10 @@ public class FloatingPointArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointArrayAttribute)) {
+        if (!(other instanceof FloatingPointArrayAttribute rhs)) {
             return false;
         }
-        FloatingPointArrayAttribute rhs = ((FloatingPointArrayAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointArray.containsAll(rhs.getFloatingPointArray())
             && rhs.getFloatingPointArray().containsAll(this.floatingPointArray);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayCodedAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayCodedAttribute.java
@@ -1,12 +1,9 @@
 package info.rexs.io.json.model.attributes;
 
 
-
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import info.rexs.io.json.model.FloatingPointArrayCoded;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -20,7 +17,7 @@ public class FloatingPointArrayCodedAttribute extends Attribute {
 
     @JsonProperty("floating_point_array_coded")
     private FloatingPointArrayCoded floatingPointArrayCoded;
-    
+
 
     @JsonProperty("floating_point_array_coded")
     public FloatingPointArrayCoded getFloatingPointArrayCoded() {
@@ -67,12 +64,12 @@ public class FloatingPointArrayCodedAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointArrayCodedAttribute) == false) {
+        if (!(other instanceof FloatingPointArrayCodedAttribute)) {
             return false;
         }
         FloatingPointArrayCodedAttribute rhs = ((FloatingPointArrayCodedAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointArrayCoded.equals(rhs.getFloatingPointArrayCoded());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayCodedAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointArrayCodedAttribute.java
@@ -64,11 +64,10 @@ public class FloatingPointArrayCodedAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointArrayCodedAttribute)) {
+        if (!(other instanceof FloatingPointArrayCodedAttribute rhs)) {
             return false;
         }
-        FloatingPointArrayCodedAttribute rhs = ((FloatingPointArrayCodedAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointArrayCoded.equals(rhs.getFloatingPointArrayCoded());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
@@ -69,11 +69,10 @@ public class FloatingPointAttribute extends Attribute{
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointAttribute)) {
+        if (!(other instanceof FloatingPointAttribute rhs)) {
             return false;
         }
-        FloatingPointAttribute rhs = ((FloatingPointAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPoint.equals(rhs.getFloatingPoint());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
@@ -21,7 +21,7 @@ public class FloatingPointAttribute extends Attribute{
     @JsonProperty("floating_point")
     private Double floatingPoint;
     @JsonIgnore
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<String, Object> additionalProperties = new HashMap<>();
 
     @JsonProperty("floating_point")
     public Double getFloatingPoint() {
@@ -73,8 +73,8 @@ public class FloatingPointAttribute extends Attribute{
             return false;
         }
         FloatingPointAttribute rhs = ((FloatingPointAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPoint.equals(rhs.getFloatingPoint());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointAttribute.java
@@ -69,7 +69,7 @@ public class FloatingPointAttribute extends Attribute{
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointAttribute) == false) {
+        if (!(other instanceof FloatingPointAttribute)) {
             return false;
         }
         FloatingPointAttribute rhs = ((FloatingPointAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
@@ -66,11 +66,10 @@ public class FloatingPointMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointMatrixAttribute)) {
+        if (!(other instanceof FloatingPointMatrixAttribute rhs)) {
             return false;
         }
-        FloatingPointMatrixAttribute rhs = ((FloatingPointMatrixAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointMatrix.containsAll(rhs.getFloatingPointMatrix())
             && rhs.getFloatingPointMatrix().containsAll(this.floatingPointMatrix);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,9 +16,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 public class FloatingPointMatrixAttribute extends Attribute {
 
-    
+
     @JsonProperty("floating_point_matrix")
-    private List<List<Double>> floatingPointMatrix = new ArrayList<List<Double>>();
+    private List<List<Double>> floatingPointMatrix = new ArrayList<>();
 
     @JsonProperty("floating_point_matrix")
     public List<List<Double>> getFloatingPointMatrix() {
@@ -70,9 +70,9 @@ public class FloatingPointMatrixAttribute extends Attribute {
             return false;
         }
         FloatingPointMatrixAttribute rhs = ((FloatingPointMatrixAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.floatingPointMatrix.containsAll(rhs.getFloatingPointMatrix()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.floatingPointMatrix.containsAll(rhs.getFloatingPointMatrix())
             && rhs.getFloatingPointMatrix().containsAll(this.floatingPointMatrix);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixAttribute.java
@@ -66,7 +66,7 @@ public class FloatingPointMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointMatrixAttribute) == false) {
+        if (!(other instanceof FloatingPointMatrixAttribute)) {
             return false;
         }
         FloatingPointMatrixAttribute rhs = ((FloatingPointMatrixAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixCodedAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixCodedAttribute.java
@@ -1,12 +1,9 @@
 package info.rexs.io.json.model.attributes;
 
 
-
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import info.rexs.io.json.model.FloatingPointMatrixCoded;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -20,7 +17,7 @@ public class FloatingPointMatrixCodedAttribute extends Attribute {
 
     @JsonProperty("floating_point_matrix_coded")
     private FloatingPointMatrixCoded floatingPointMatrixCoded;
-    
+
 
     @JsonProperty("floating_point_matrix_coded")
     public FloatingPointMatrixCoded getFloatingPointMatrixCoded() {
@@ -67,12 +64,12 @@ public class FloatingPointMatrixCodedAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof FloatingPointMatrixCodedAttribute) == false) {
+        if (!(other instanceof FloatingPointMatrixCodedAttribute)) {
             return false;
         }
         FloatingPointMatrixCodedAttribute rhs = ((FloatingPointMatrixCodedAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointMatrixCoded.equals(rhs.getFloatingPointMatrixCoded());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixCodedAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/FloatingPointMatrixCodedAttribute.java
@@ -64,11 +64,10 @@ public class FloatingPointMatrixCodedAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof FloatingPointMatrixCodedAttribute)) {
+        if (!(other instanceof FloatingPointMatrixCodedAttribute rhs)) {
             return false;
         }
-        FloatingPointMatrixCodedAttribute rhs = ((FloatingPointMatrixCodedAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.floatingPointMatrixCoded.equals(rhs.getFloatingPointMatrixCoded());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
@@ -65,11 +65,10 @@ public class IntegerArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof IntegerArrayAttribute)) {
+        if (!(other instanceof IntegerArrayAttribute rhs)) {
             return false;
         }
-        IntegerArrayAttribute rhs = ((IntegerArrayAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.integerArray.containsAll(rhs.getIntegerArray())
             && rhs.getIntegerArray().containsAll(this.integerArray);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class IntegerArrayAttribute extends Attribute {
 
     @JsonProperty("integer_array")
-    private List<Integer> integerArray = new ArrayList<Integer>();
+    private List<Integer> integerArray = new ArrayList<>();
 
     @JsonProperty("integer_array")
     public List<Integer> getIntegerArray() {
@@ -69,9 +69,9 @@ public class IntegerArrayAttribute extends Attribute {
             return false;
         }
         IntegerArrayAttribute rhs = ((IntegerArrayAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.integerArray.containsAll(rhs.getIntegerArray()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.integerArray.containsAll(rhs.getIntegerArray())
             && rhs.getIntegerArray().containsAll(this.integerArray);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerArrayAttribute.java
@@ -65,7 +65,7 @@ public class IntegerArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof IntegerArrayAttribute) == false) {
+        if (!(other instanceof IntegerArrayAttribute)) {
             return false;
         }
         IntegerArrayAttribute rhs = ((IntegerArrayAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerAttribute.java
@@ -1,14 +1,5 @@
 package info.rexs.io.json.model.attributes;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-
-
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -24,7 +15,7 @@ public class IntegerAttribute extends Attribute {
 
     @JsonProperty("integer")
     private Integer integer;
-    
+
 
     @JsonProperty("integer")
     public Integer getInteger() {
@@ -71,12 +62,12 @@ public class IntegerAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof IntegerAttribute) == false) {
+        if (!(other instanceof IntegerAttribute)) {
             return false;
         }
         IntegerAttribute rhs = ((IntegerAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.integer.equals(rhs.getInteger());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerAttribute.java
@@ -62,11 +62,10 @@ public class IntegerAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof IntegerAttribute)) {
+        if (!(other instanceof IntegerAttribute rhs)) {
             return false;
         }
-        IntegerAttribute rhs = ((IntegerAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.integer.equals(rhs.getInteger());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
@@ -66,11 +66,10 @@ public class IntegerMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof IntegerMatrixAttribute)) {
+        if (!(other instanceof IntegerMatrixAttribute rhs)) {
             return false;
         }
-        IntegerMatrixAttribute rhs = ((IntegerMatrixAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.integerMatrix.containsAll(rhs.getIntegerMatrix())
             && rhs.getIntegerMatrix().containsAll(this.integerMatrix);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
@@ -66,7 +66,7 @@ public class IntegerMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof IntegerMatrixAttribute) == false) {
+        if (!(other instanceof IntegerMatrixAttribute)) {
             return false;
         }
         IntegerMatrixAttribute rhs = ((IntegerMatrixAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/IntegerMatrixAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,9 +16,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 public class IntegerMatrixAttribute extends Attribute {
 
-    
+
     @JsonProperty("integer_matrix")
-    private List<List<Integer>> integerMatrix = new ArrayList<List<Integer>>();
+    private List<List<Integer>> integerMatrix = new ArrayList<>();
 
     @JsonProperty("integer_matrix")
     public List<List<Integer>> getIntegerMatrix() {
@@ -70,9 +70,9 @@ public class IntegerMatrixAttribute extends Attribute {
             return false;
         }
         IntegerMatrixAttribute rhs = ((IntegerMatrixAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.integerMatrix.containsAll(rhs.getIntegerMatrix()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.integerMatrix.containsAll(rhs.getIntegerMatrix())
             && rhs.getIntegerMatrix().containsAll(this.integerMatrix);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/ReferenceComponentAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/ReferenceComponentAttribute.java
@@ -16,7 +16,7 @@ public class ReferenceComponentAttribute extends Attribute {
 
     @JsonProperty("reference_component")
     private Integer referenceComponent;
-    
+
     @JsonProperty("reference_component")
     public Integer getReferenceComponent() {
         return referenceComponent;
@@ -62,12 +62,12 @@ public class ReferenceComponentAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof ReferenceComponentAttribute) == false) {
+        if (!(other instanceof ReferenceComponentAttribute)) {
             return false;
         }
         ReferenceComponentAttribute rhs = ((ReferenceComponentAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.referenceComponent.equals(rhs.getReferenceComponent());
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/ReferenceComponentAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/ReferenceComponentAttribute.java
@@ -62,11 +62,10 @@ public class ReferenceComponentAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof ReferenceComponentAttribute)) {
+        if (!(other instanceof ReferenceComponentAttribute rhs)) {
             return false;
         }
-        ReferenceComponentAttribute rhs = ((ReferenceComponentAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.referenceComponent.equals(rhs.getReferenceComponent());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
@@ -65,11 +65,10 @@ public class StringArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof StringArrayAttribute)) {
+        if (!(other instanceof StringArrayAttribute rhs)) {
             return false;
         }
-        StringArrayAttribute rhs = ((StringArrayAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.stringArray.containsAll(rhs.getStringArray())
             && rhs.getStringArray().containsAll(this.stringArray);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
@@ -65,7 +65,7 @@ public class StringArrayAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof StringArrayAttribute) == false) {
+        if (!(other instanceof StringArrayAttribute)) {
             return false;
         }
         StringArrayAttribute rhs = ((StringArrayAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringArrayAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class StringArrayAttribute extends Attribute {
 
     @JsonProperty("string_array")
-    private List<String> stringArray = new ArrayList<String>();
+    private List<String> stringArray = new ArrayList<>();
 
     @JsonProperty("string_array")
     public List<String> getStringArray() {
@@ -69,9 +69,9 @@ public class StringArrayAttribute extends Attribute {
             return false;
         }
         StringArrayAttribute rhs = ((StringArrayAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.stringArray.containsAll(rhs.getStringArray()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.stringArray.containsAll(rhs.getStringArray())
             && rhs.getStringArray().containsAll(this.stringArray);
     }
 

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
@@ -1,12 +1,5 @@
 package info.rexs.io.json.model.attributes;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -69,7 +62,7 @@ public class StringAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof StringAttribute) == false) {
+        if (!(other instanceof StringAttribute)) {
             return false;
         }
         StringAttribute rhs = ((StringAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringAttribute.java
@@ -62,11 +62,10 @@ public class StringAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof StringAttribute)) {
+        if (!(other instanceof StringAttribute rhs)) {
             return false;
         }
-        StringAttribute rhs = ((StringAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.string.equals(rhs.getString());
     }

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
@@ -66,11 +66,10 @@ public class StringMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if (!(other instanceof StringMatrixAttribute)) {
+        if (!(other instanceof StringMatrixAttribute rhs)) {
             return false;
         }
-        StringMatrixAttribute rhs = ((StringMatrixAttribute) other);
-        return (this.id.equals(rhs.getId()))
+		return (this.id.equals(rhs.getId()))
             && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
             && this.stringMatrix.containsAll(rhs.getStringMatrix())
             && rhs.getStringMatrix().containsAll(this.stringMatrix);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
@@ -66,7 +66,7 @@ public class StringMatrixAttribute extends Attribute {
         if (other == this) {
             return true;
         }
-        if ((other instanceof StringMatrixAttribute) == false) {
+        if (!(other instanceof StringMatrixAttribute)) {
             return false;
         }
         StringMatrixAttribute rhs = ((StringMatrixAttribute) other);

--- a/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
+++ b/api/src/main/java/info/rexs/io/json/model/attributes/StringMatrixAttribute.java
@@ -1,7 +1,7 @@
 package info.rexs.io.json.model.attributes;
+
 import java.util.ArrayList;
 import java.util.List;
-
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,9 +16,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 public class StringMatrixAttribute extends Attribute {
 
-    
+
     @JsonProperty("string_matrix")
-    private List<List<String>> stringMatrix = new ArrayList<List<String>>();
+    private List<List<String>> stringMatrix = new ArrayList<>();
 
     @JsonProperty("string_matrix")
     public List<List<String>> getStringMatrix() {
@@ -70,9 +70,9 @@ public class StringMatrixAttribute extends Attribute {
             return false;
         }
         StringMatrixAttribute rhs = ((StringMatrixAttribute) other);
-        return (this.id.equals(rhs.getId())) 
-            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null) 
-            && this.stringMatrix.containsAll(rhs.getStringMatrix()) 
+        return (this.id.equals(rhs.getId()))
+            && (this.unit != null && rhs.unit != null && this.unit.equals(rhs.getUnit())|| this.unit == null || rhs.unit == null)
+            && this.stringMatrix.containsAll(rhs.getStringMatrix())
             && rhs.getStringMatrix().containsAll(this.stringMatrix);
     }
 

--- a/api/src/main/java/info/rexs/model/RexsComponent.java
+++ b/api/src/main/java/info/rexs/model/RexsComponent.java
@@ -1053,10 +1053,9 @@ public class RexsComponent implements Comparable<RexsComponent> {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsComponent)) {
+		if (!(o instanceof RexsComponent other)) {
 			return false;
 		}
-		RexsComponent other = (RexsComponent)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/model/RexsComponent.java
+++ b/api/src/main/java/info/rexs/model/RexsComponent.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import info.rexs.schema.constants.RexsAttributeId;
 import info.rexs.schema.constants.RexsComponentType;
@@ -1061,7 +1062,7 @@ public class RexsComponent implements Comparable<RexsComponent> {
 		}
 		Object this_id = getId();
 		Object other_id = other.getId();
-		return this_id == null ? other_id == null : this_id.equals(other_id);
+		return Objects.equals(this_id, other_id);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/model/RexsModel.java
+++ b/api/src/main/java/info/rexs/model/RexsModel.java
@@ -176,7 +176,7 @@ public class RexsModel {
 	 * 				All components of the model as a {@link List} of {@link RexsComponent} sorted by component Id.
 	 */
 	public List<RexsComponent> getComponentsSorted() {
-		return components.keySet().stream().sorted().map(id -> getComponent(id)).collect(Collectors.toList());
+		return components.keySet().stream().sorted().map(this::getComponent).collect(Collectors.toList());
 	}
 
 	/**

--- a/api/src/main/java/info/rexs/model/RexsSubModel.java
+++ b/api/src/main/java/info/rexs/model/RexsSubModel.java
@@ -65,7 +65,7 @@ public class RexsSubModel implements Comparable<RexsSubModel> {
 	 * Constructs a new {@link RexsSubModel} for an accumilation.
 	 */
 	protected RexsSubModel() {
-		this((Integer)null, true);
+		this(null, true);
 	}
 
 	/**

--- a/api/src/main/java/info/rexs/model/RexsSubModel.java
+++ b/api/src/main/java/info/rexs/model/RexsSubModel.java
@@ -18,6 +18,7 @@ package info.rexs.model;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
@@ -185,12 +186,12 @@ public class RexsSubModel implements Comparable<RexsSubModel> {
 		}
 		Object this_id = getId();
 		Object other_id = other.getId();
-		if (this_id == null ? other_id != null : !this_id.equals(other_id)) {
+		if (!Objects.equals(this_id, other_id)) {
 			return false;
 		}
 		Object this_isAccumulation = isAccumulation();
 		Object other_isAccumulation = other.isAccumulation();
-		return this_isAccumulation == null ? other_isAccumulation == null : this_isAccumulation.equals(other_isAccumulation);
+		return Objects.equals(this_isAccumulation, other_isAccumulation);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/model/RexsSubModel.java
+++ b/api/src/main/java/info/rexs/model/RexsSubModel.java
@@ -177,10 +177,9 @@ public class RexsSubModel implements Comparable<RexsSubModel> {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsSubModel)) {
+		if (!(o instanceof RexsSubModel other)) {
 			return false;
 		}
-		RexsSubModel other = (RexsSubModel)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/model/transformer/IRexsModelTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/IRexsModelTransformer.java
@@ -33,7 +33,7 @@ public interface IRexsModelTransformer<E> {
 	 * @return
 	 * 				The REXS model in the foreign model.
 	 */
-	public E transform(RexsModel model);
+	E transform(RexsModel model);
 
 	/**
 	 * Transforms a foreign model to a REXS model.
@@ -44,5 +44,5 @@ public interface IRexsModelTransformer<E> {
 	 * @return
 	 * 				The REXS model as a {@link RexsModel}.
 	 */
-	public RexsModel transform(E model);
+	RexsModel transform(E model);
 }

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
@@ -7,12 +7,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-import info.rexs.schema.RexsSchemaRegistry;
-import info.rexs.schema.constants.RexsValueType;
-import info.rexs.schema.constants.RexsVersion;
-import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
-import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
-import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 import info.rexs.io.json.model.Accumulation;
 import info.rexs.io.json.model.Component;
 import info.rexs.io.json.model.FloatingPointArrayCoded;
@@ -28,6 +22,7 @@ import info.rexs.io.json.model.attributes.Attribute;
 import info.rexs.io.json.model.attributes.BooleanArrayAttribute;
 import info.rexs.io.json.model.attributes.BooleanAttribute;
 import info.rexs.io.json.model.attributes.BooleanMatrixAttribute;
+import info.rexs.io.json.model.attributes.DateTimeAttribute;
 import info.rexs.io.json.model.attributes.EnumArrayAttribute;
 import info.rexs.io.json.model.attributes.EnumAttribute;
 import info.rexs.io.json.model.attributes.FileReferenceAttribute;
@@ -36,7 +31,6 @@ import info.rexs.io.json.model.attributes.FloatingPointArrayCodedAttribute;
 import info.rexs.io.json.model.attributes.FloatingPointAttribute;
 import info.rexs.io.json.model.attributes.FloatingPointMatrixAttribute;
 import info.rexs.io.json.model.attributes.FloatingPointMatrixCodedAttribute;
-import info.rexs.io.json.model.attributes.DateTimeAttribute;
 import info.rexs.io.json.model.attributes.IntegerArrayAttribute;
 import info.rexs.io.json.model.attributes.IntegerAttribute;
 import info.rexs.io.json.model.attributes.IntegerMatrixAttribute;
@@ -62,6 +56,12 @@ import info.rexs.model.value.RexsAttributeValueArrayOfArrays;
 import info.rexs.model.value.RexsAttributeValueMatrix;
 import info.rexs.model.value.RexsAttributeValueMatrixBase64;
 import info.rexs.model.value.RexsAttributeValueScalar;
+import info.rexs.schema.RexsSchemaRegistry;
+import info.rexs.schema.constants.RexsValueType;
+import info.rexs.schema.constants.RexsVersion;
+import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
+import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
+import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 
 
 /**
@@ -343,7 +343,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			return new FloatingPointMatrixCodedAttribute().withFloatingPointMatrixCoded(fpac);
 		}
 		else if (value instanceof RexsAttributeValueArrayOfArrays) {
-			List<Integer[]> valueString = ((RexsAttributeValueArrayOfArrays) value).getValueArrayOfIntegerArrays();
+			List<Integer[]> valueString = value.getValueArrayOfIntegerArrays();
 			return new ArrayOfIntegerArraysAttribute().withArrayOfIntegerArrays(valueString.stream().map(array -> Arrays.asList(array)).toList());
 		}
 		else

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
@@ -211,8 +211,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			case ENUM_ARRAY:
 				jsonAttribute = new EnumArrayAttribute().withEnumArray(attribute.hasValue() ? Arrays.asList(attribute.getStringArrayValue()) : null ); break;
 			case FLOATING_POINT_ARRAY:
-				if (value instanceof RexsAttributeValueArrayBase64) {
-					RexsAttributeValueArrayBase64 valueBase64 = (RexsAttributeValueArrayBase64) value;
+				if (value instanceof RexsAttributeValueArrayBase64 valueBase64) {
 					Base64Type code = valueBase64.getRawType();
 					FloatingPointArrayCoded fpac = new FloatingPointArrayCoded()
 							.withCode(code == null? null: code.toString())
@@ -228,8 +227,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			case BOOLEAN_MATRIX:
 				jsonAttribute = new BooleanMatrixAttribute().withBooleanMatrix(attribute.hasValue() ? (get2DArrayAsList(attribute.getBooleanMatrixValue())) : null ); break;
 			case FLOATING_POINT_MATRIX:
-				if (value instanceof RexsAttributeValueMatrixBase64) {
-					RexsAttributeValueMatrixBase64 valueBase64 = (RexsAttributeValueMatrixBase64) value;
+				if (value instanceof RexsAttributeValueMatrixBase64 valueBase64) {
 					Base64Type code = valueBase64.getRawType();
 					FloatingPointMatrixCoded fpac = new FloatingPointMatrixCoded()
 							.withCode(code == null? null: code.toString())
@@ -282,8 +280,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			// if nothing else fits use string
 			return new StringAttribute().withString(valueString);
 		}
-		else if (value instanceof RexsAttributeValueArray) {
-			RexsAttributeValueArray arrayValue = (RexsAttributeValueArray) value;
+		else if (value instanceof RexsAttributeValueArray arrayValue) {
 			List<String> valueString = arrayValue.getRawValue();
 			if (valueString==null || valueString.isEmpty() || valueString.get(0)==null || valueString.get(0).isEmpty())
 				return new StringArrayAttribute().withStringArray(valueString);
@@ -303,16 +300,14 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			// if nothing else fits use string
 			return new StringArrayAttribute().withStringArray(valueString);
 		}
-		else if (value instanceof RexsAttributeValueArrayBase64) {
-			RexsAttributeValueArrayBase64 valueBase64 = (RexsAttributeValueArrayBase64) value;
+		else if (value instanceof RexsAttributeValueArrayBase64 valueBase64) {
 			Base64Type code = valueBase64.getRawType();
 			FloatingPointArrayCoded fpac = new FloatingPointArrayCoded()
 					.withCode(code == null? null: code.toString())
 					.withValue(valueBase64.getRawValue());
 			return new FloatingPointArrayCodedAttribute().withFloatingPointArrayCoded(fpac);
 		}
-		else if (value instanceof RexsAttributeValueMatrix) {
-			RexsAttributeValueMatrix matrixValue = (RexsAttributeValueMatrix) value;
+		else if (value instanceof RexsAttributeValueMatrix matrixValue) {
 			List<List<String>> valueString = matrixValue.getRawValue();
 			if (valueString==null || valueString.isEmpty() || valueString.get(0)==null || valueString.get(0).isEmpty() || valueString.get(0).get(0)==null || valueString.get(0).get(0).isEmpty())
 				return new StringMatrixAttribute().withStringMatrix(valueString);
@@ -332,8 +327,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			// if nothing else fits use string
 			return new StringMatrixAttribute().withStringMatrix(valueString);
 		}
-		else if (value instanceof RexsAttributeValueMatrixBase64) {
-			RexsAttributeValueMatrixBase64 valueBase64 = (RexsAttributeValueMatrixBase64) value;
+		else if (value instanceof RexsAttributeValueMatrixBase64 valueBase64) {
 			Base64Type code = valueBase64.getRawType();
 			FloatingPointMatrixCoded fpac = new FloatingPointMatrixCoded()
 					.withCode(code == null? null: code.toString())

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelJsonTransformer.java
@@ -142,7 +142,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 
 	private List<Component> createComponentsJson(List<RexsComponent> components) {
 		List<Component> componentsJson = new ArrayList<>();
-		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(component -> component.getId())).toList();
+		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(RexsComponent::getId)).toList();
 		for (RexsComponent component : sortedComponents)
 			componentsJson.add(createComponentJson(component));
 		return componentsJson;
@@ -288,16 +288,16 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			if (valueString==null || valueString.isEmpty() || valueString.get(0)==null || valueString.get(0).isEmpty())
 				return new StringArrayAttribute().withStringArray(valueString);
 			else if (valueString.get(0).equals("true") || valueString.get(0).equals("false"))
-				return new BooleanArrayAttribute().withBooleanArray(valueString.stream().map(s -> Boolean.valueOf(s)).toList());
+				return new BooleanArrayAttribute().withBooleanArray(valueString.stream().map(Boolean::valueOf).toList());
 			else if (!unit.equals(RexsStandardUnitIds.none.getId()))
-				return new FloatingPointArrayAttribute().withFloatingPointArray(valueString.stream().map(s -> Double.valueOf(s)).toList());
+				return new FloatingPointArrayAttribute().withFloatingPointArray(valueString.stream().map(Double::valueOf).toList());
 			// if nothing better is known try valueOf...
 			try {
-				return new IntegerArrayAttribute().withIntegerArray(valueString.stream().map(s -> Integer.valueOf(s)).toList());
+				return new IntegerArrayAttribute().withIntegerArray(valueString.stream().map(Integer::valueOf).toList());
 			}
 			catch (NumberFormatException e) {}
 			try {
-				return new FloatingPointArrayAttribute().withFloatingPointArray(valueString.stream().map(s -> Double.valueOf(s)).toList());
+				return new FloatingPointArrayAttribute().withFloatingPointArray(valueString.stream().map(Double::valueOf).toList());
 			}
 			catch (NumberFormatException e) {}
 			// if nothing else fits use string
@@ -317,16 +317,16 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			if (valueString==null || valueString.isEmpty() || valueString.get(0)==null || valueString.get(0).isEmpty() || valueString.get(0).get(0)==null || valueString.get(0).get(0).isEmpty())
 				return new StringMatrixAttribute().withStringMatrix(valueString);
 			else if (valueString.get(0).get(0).equals("true") || valueString.get(0).get(0).equals("false"))
-				return new BooleanMatrixAttribute().withBooleanMatrix(valueString.stream().map(list -> list.stream().map(s -> Boolean.valueOf(s)).toList()).toList());
+				return new BooleanMatrixAttribute().withBooleanMatrix(valueString.stream().map(list -> list.stream().map(Boolean::valueOf).toList()).toList());
 			else if (!unit.equals(RexsStandardUnitIds.none.getId()))
-				return new FloatingPointMatrixAttribute().withFloatingPointMatrix(valueString.stream().map(list -> list.stream().map(s -> Double.valueOf(s)).toList()).toList());
+				return new FloatingPointMatrixAttribute().withFloatingPointMatrix(valueString.stream().map(list -> list.stream().map(Double::valueOf).toList()).toList());
 			// if nothing better is known try valueOf...
 			try {
-				return new IntegerMatrixAttribute().withIntegerMatrix(valueString.stream().map(list -> list.stream().map(s -> Integer.valueOf(s)).toList()).toList());
+				return new IntegerMatrixAttribute().withIntegerMatrix(valueString.stream().map(list -> list.stream().map(Integer::valueOf).toList()).toList());
 			}
 			catch (NumberFormatException e) {}
 			try {
-				return new BooleanMatrixAttribute().withBooleanMatrix(valueString.stream().map(list -> list.stream().map(s -> Boolean.valueOf(s)).toList()).toList());
+				return new BooleanMatrixAttribute().withBooleanMatrix(valueString.stream().map(list -> list.stream().map(Boolean::valueOf).toList()).toList());
 			}
 			catch (NumberFormatException e) {}
 			// if nothing else fits use string
@@ -344,7 +344,7 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 		}
 		else if (value instanceof RexsAttributeValueArrayOfArrays) {
 			List<Integer[]> valueString = value.getValueArrayOfIntegerArrays();
-			return new ArrayOfIntegerArraysAttribute().withArrayOfIntegerArrays(valueString.stream().map(array -> Arrays.asList(array)).toList());
+			return new ArrayOfIntegerArraysAttribute().withArrayOfIntegerArrays(valueString.stream().map(Arrays::asList).toList());
 		}
 		else
 			throw new RexsModelAccessException("unkown value type: "+value);
@@ -507,14 +507,14 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			List<List<Integer>> jsonValue = ((IntegerMatrixAttribute) attributeJson).getIntegerMatrix();
 			List<List<String>> stringValue = new ArrayList<>();
 			for (List<Integer> list : jsonValue)
-				stringValue.add(list.stream().map(entry -> entry.toString()).toList());
+				stringValue.add(list.stream().map(Object::toString).toList());
 			return new RexsAttributeValueMatrix(stringValue);
 		}
 		if(attributeJson instanceof FloatingPointMatrixAttribute){
 			List<List<Double>> jsonValue = ((FloatingPointMatrixAttribute) attributeJson).getFloatingPointMatrix();
 			List<List<String>> stringValue = new ArrayList<>();
 			for (List<Double> list : jsonValue)
-				stringValue.add(list.stream().map(entry -> entry.toString()).toList());
+				stringValue.add(list.stream().map(Object::toString).toList());
 			return new RexsAttributeValueMatrix(stringValue);
 		}
 		if(attributeJson instanceof FloatingPointMatrixCodedAttribute){
@@ -525,14 +525,14 @@ public class RexsModelJsonTransformer implements IRexsModelTransformer<JSONModel
 			List<List<Boolean>> jsonValue = ((BooleanMatrixAttribute) attributeJson).getBooleanMatrix();
 			List<List<String>> stringValue = new ArrayList<>();
 			for (List<Boolean> list : jsonValue)
-				stringValue.add(list.stream().map(entry -> entry.toString()).toList());
+				stringValue.add(list.stream().map(Object::toString).toList());
 			return new RexsAttributeValueMatrix(stringValue);
 		}
 		if(attributeJson instanceof ArrayOfIntegerArraysAttribute){
 			List<List<Integer>> jsonValue = ((ArrayOfIntegerArraysAttribute) attributeJson).getArrayOfIntegerArrays();
 			List<List<String>> stringValue = new ArrayList<>();
 			for (List<Integer> list : jsonValue)
-				stringValue.add(list.stream().map(entry -> entry.toString()).toList());
+				stringValue.add(list.stream().map(Object::toString).toList());
 			return new RexsAttributeValueMatrix(stringValue);
 		}
 		return null;

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
@@ -23,10 +23,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import info.rexs.schema.constants.RexsVersion;
-import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
-import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
-import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 import info.rexs.model.RexsAttribute;
 import info.rexs.model.RexsComponent;
 import info.rexs.model.RexsLoadSpectrum;
@@ -63,6 +59,10 @@ import info.rexs.model.value.RexsAttributeValueArrayOfArrays;
 import info.rexs.model.value.RexsAttributeValueMatrix;
 import info.rexs.model.value.RexsAttributeValueMatrixBase64;
 import info.rexs.model.value.RexsAttributeValueScalar;
+import info.rexs.schema.constants.RexsVersion;
+import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
+import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
+import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 
 /**
  * This class is a {@link IRexsModelTransformer} to transform REXS models of the types {@link RexsModel} and {@link Model}.
@@ -115,7 +115,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 
 		Relations relationsXml = objectFactory.createRelations();
 
-		List<RexsRelation> sortedRelations = relations.stream().sorted(Comparator.comparingInt(rel -> rel.getId())).toList();
+		List<RexsRelation> sortedRelations = relations.stream().sorted(Comparator.comparingInt(RexsRelation::getId)).toList();
 		for (RexsRelation relation : sortedRelations) {
 			relationsXml.getRelation().add(createRelationXml(relation));
 		}
@@ -156,7 +156,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 
 		Components componentsXml = objectFactory.createComponents();
 
-		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(component -> component.getId())).toList();
+		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(RexsComponent::getId)).toList();
 		for (RexsComponent component : sortedComponents) {
 			componentsXml.getComponent().add(createComponentXml(component));
 		}
@@ -373,7 +373,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 		LoadCase loadCaseXml = objectFactory.createLoadCase();
 		loadCaseXml.setId(loadCase.getId());
 
-		List<RexsComponent> sortedComponents = loadCase.getComponents().stream().sorted(Comparator.comparingInt(component -> component.getId())).toList();
+		List<RexsComponent> sortedComponents = loadCase.getComponents().stream().sorted(Comparator.comparingInt(RexsComponent::getId)).toList();
 		for (RexsComponent component : sortedComponents) {
 			loadCaseXml.getComponent().add(createComponentXml(component));
 		}
@@ -391,7 +391,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 
 		Accumulation accumulationXml = objectFactory.createAccumulation();
 
-		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(component -> component.getId())).toList();
+		List<RexsComponent> sortedComponents = components.stream().sorted(Comparator.comparingInt(RexsComponent::getId)).toList();
 		for (RexsComponent component : sortedComponents) {
 			accumulationXml.getComponent().add(createComponentXml(component));
 		}

--- a/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
+++ b/api/src/main/java/info/rexs/model/transformer/RexsModelXmlTransformer.java
@@ -222,8 +222,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 	}
 
 	private Object createAttributeContentXml(AbstractRexsAttributeValue value) {
-		if (value instanceof RexsAttributeValueScalar) {
-			RexsAttributeValueScalar valueScalar = (RexsAttributeValueScalar)value;
+		if (value instanceof RexsAttributeValueScalar valueScalar) {
 			return valueScalar.getRawValue() != null ? valueScalar.getRawValue() : "";
 
 		} else if (value instanceof AbstractRexsAttributeValueArray) {
@@ -257,8 +256,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 				array.getContent().add(c);
 			}
 
-		} else if (value instanceof RexsAttributeValueArrayBase64) {
-			RexsAttributeValueArrayBase64 valueBase64 = (RexsAttributeValueArrayBase64)value;
+		} else if (value instanceof RexsAttributeValueArrayBase64 valueBase64) {
 			if (valueBase64.getRawValue() == null)
 				return null;
 
@@ -292,8 +290,7 @@ public class RexsModelXmlTransformer implements IRexsModelTransformer<Model> {
 				matrix.getContent().add(row);
 			}
 
-		} else if (value instanceof RexsAttributeValueMatrixBase64) {
-			RexsAttributeValueMatrixBase64 valueBase64 = (RexsAttributeValueMatrixBase64)value;
+		} else if (value instanceof RexsAttributeValueMatrixBase64 valueBase64) {
 			if (valueBase64.getRawValue() == null)
 				return null;
 

--- a/api/src/main/java/info/rexs/schema/IRexsSchemaRegistry.java
+++ b/api/src/main/java/info/rexs/schema/IRexsSchemaRegistry.java
@@ -38,7 +38,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public RexsUnitId getAttributeUnit(String rexsAttributeId, RexsVersion version);
+	RexsUnitId getAttributeUnit(String rexsAttributeId, RexsVersion version);
 
 	/**
 	 * returns the RexsValueType of the attribute in the specified REXS version
@@ -46,7 +46,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public RexsValueType getAttributeType(String rexsAttributeId, RexsVersion version);
+	RexsValueType getAttributeType(String rexsAttributeId, RexsVersion version);
 
 	/**
 	 * returns the (translated) name of the attribute in the specified REXS version
@@ -54,7 +54,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public String getAttributeName(String attributeId, RexsVersion version);
+	String getAttributeName(String attributeId, RexsVersion version);
 
 	/**
 	 * returns the symbol of the attribute in the specified REXS version
@@ -62,7 +62,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public String getAttributeSymbol(String attributeId, RexsVersion version);
+	String getAttributeSymbol(String attributeId, RexsVersion version);
 
 	/**
 	 * returns the (translated) name of an enum value of an enum attribute
@@ -71,7 +71,7 @@ public interface IRexsSchemaRegistry {
 	 * @param value
 	 * @return
 	 */
-	public String getNameForEnumValue(String attributeId, RexsVersion version, String value);
+	String getNameForEnumValue(String attributeId, RexsVersion version, String value);
 
 	/**
 	 * returns true if this attribute is mapped to this component type in the specified REXS version
@@ -80,7 +80,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public boolean componentAttributeMappingExists(String rexsAttributeId, RexsComponentType rexsCompType, RexsVersion version);
+	boolean componentAttributeMappingExists(String rexsAttributeId, RexsComponentType rexsCompType, RexsVersion version);
 
 	/**
 	 * returns the list of component types which are mapped to this attribute in the specified REXS version
@@ -88,7 +88,7 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public List<RexsComponentType> getAvailableComponentTypesForAttributeId(String rexsAttributeId, RexsVersion version);
+	List<RexsComponentType> getAvailableComponentTypesForAttributeId(String rexsAttributeId, RexsVersion version);
 
 	/**
 	 * returns the list of attributes which are mapped to this component type in the specified REXS version
@@ -96,15 +96,15 @@ public interface IRexsSchemaRegistry {
 	 * @param version
 	 * @return
 	 */
-	public List<String> getAttributeIdsOfComponentType(RexsComponentType rexsComponentType, RexsVersion version);
+	List<String> getAttributeIdsOfComponentType(RexsComponentType rexsComponentType, RexsVersion version);
 
-	public RexsVersion getVersion(String version);
+	RexsVersion getVersion(String version);
 
-	public RexsComponentType getComponentType(RexsVersion version, String componentType);
+	RexsComponentType getComponentType(RexsVersion version, String componentType);
 
-	public boolean hasAttributeWithId(RexsVersion version, String attributeId);
+	boolean hasAttributeWithId(RexsVersion version, String attributeId);
 
-	public boolean hasRelationTypes(RexsVersion version);
+	boolean hasRelationTypes(RexsVersion version);
 
-	public List<List<AllowedCombinationRole>> getAllowedCombinationsForRelation(RexsVersion version, RexsRelationType relationType);
+	List<List<AllowedCombinationRole>> getAllowedCombinationsForRelation(RexsVersion version, RexsRelationType relationType);
 }

--- a/api/src/main/java/info/rexs/schema/RexsSchemaFile.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaFile.java
@@ -149,10 +149,9 @@ public class RexsSchemaFile {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsSchemaFile)) {
+		if (!(o instanceof RexsSchemaFile other)) {
 			return false;
 		}
-		RexsSchemaFile other = (RexsSchemaFile)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/schema/RexsSchemaFile.java
+++ b/api/src/main/java/info/rexs/schema/RexsSchemaFile.java
@@ -17,6 +17,7 @@ package info.rexs.schema;
 
 import java.io.InputStream;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import info.rexs.schema.constants.RexsVersion;
@@ -157,7 +158,7 @@ public class RexsSchemaFile {
 		}
 		Object this_version = getVersion();
 		Object other_version = other.getVersion();
-		return this_version == null ? other_version == null : this_version.equals(other_version);
+		return Objects.equals(this_version, other_version);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/schema/constants/RexsAttributeId.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsAttributeId.java
@@ -126,10 +126,9 @@ public class RexsAttributeId implements RexsStandardAttributeIds {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsAttributeId)) {
+		if (!(o instanceof RexsAttributeId other)) {
 			return false;
 		}
-		RexsAttributeId other = (RexsAttributeId)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/schema/constants/RexsAttributeId.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsAttributeId.java
@@ -17,6 +17,7 @@ package info.rexs.schema.constants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
 
@@ -134,12 +135,12 @@ public class RexsAttributeId implements RexsStandardAttributeIds {
 		}
 		Object this_id = getId();
 		Object other_id = other.getId();
-		if (this_id == null ? other_id != null : !this_id.equals(other_id)) {
+		if (!Objects.equals(this_id, other_id)) {
 			return false;
 		}
 		Object this_unit = getUnit();
 		Object other_unit = other.getUnit();
-		return this_unit == null ? other_unit == null : this_unit.equals(other_unit);
+		return Objects.equals(this_unit, other_unit);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/schema/constants/RexsComponentType.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsComponentType.java
@@ -118,10 +118,9 @@ public class RexsComponentType implements RexsStandardComponentTypes {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsComponentType)) {
+		if (!(o instanceof RexsComponentType other)) {
 			return false;
 		}
-		RexsComponentType other = (RexsComponentType)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/schema/constants/RexsComponentType.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsComponentType.java
@@ -17,6 +17,7 @@ package info.rexs.schema.constants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 
@@ -126,7 +127,7 @@ public class RexsComponentType implements RexsStandardComponentTypes {
 		}
 		Object this_id = getId();
 		Object other_id = other.getId();
-		return this_id == null ? other_id == null : this_id.equals(other_id);
+		return Objects.equals(this_id, other_id);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/schema/constants/RexsRelationRole.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsRelationRole.java
@@ -110,10 +110,9 @@ public class RexsRelationRole implements RexsStandardRelationRoles {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsRelationRole)) {
+		if (!(o instanceof RexsRelationRole other)) {
 			return false;
 		}
-		RexsRelationRole other = (RexsRelationRole)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/schema/constants/RexsRelationRole.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsRelationRole.java
@@ -17,6 +17,7 @@ package info.rexs.schema.constants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 
@@ -118,7 +119,7 @@ public class RexsRelationRole implements RexsStandardRelationRoles {
 		}
 		Object this_key = getKey();
 		Object other_key = other.getKey();
-		return this_key == null ? other_key == null : this_key.equals(other_key);
+		return Objects.equals(this_key, other_key);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/schema/constants/RexsRelationType.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsRelationType.java
@@ -136,10 +136,9 @@ public class RexsRelationType implements RexsStandardRelationTypes {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof RexsRelationType)) {
+		if (!(o instanceof RexsRelationType other)) {
 			return false;
 		}
-		RexsRelationType other = (RexsRelationType)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/schema/constants/RexsRelationType.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsRelationType.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import info.rexs.schema.constants.standard.RexsStandardRelationTypes;
 
@@ -144,7 +145,7 @@ public class RexsRelationType implements RexsStandardRelationTypes {
 		}
 		Object this_key = getKey();
 		Object other_key = other.getKey();
-		return this_key == null ? other_key == null : this_key.equals(other_key);
+		return Objects.equals(this_key, other_key);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelChangelogUpgrader.java
@@ -262,7 +262,7 @@ public class ModelChangelogUpgrader {
 			RexsComponent component,
 			RexsAttribute attribute,
 			RexsValueType oldType,
-			RexsValueType newType) throws RexsUpgradeException {
+			RexsValueType newType) {
 
 		String rawValue = attribute.getRawValue().getValueString();
 		switch(newType) {

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgrader.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgrader.java
@@ -36,5 +36,5 @@ public interface ModelUpgrader {
 	 * @throws RexsUpgradeException
 	 * 				If an unexpected error occurs during the upgrade process.
 	 */
-	public ModelUpgraderResult upgrade(RexsModel rexsModel, boolean strictMode) throws RexsUpgradeException;
+	ModelUpgraderResult upgrade(RexsModel rexsModel, boolean strictMode) throws RexsUpgradeException;
 }

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV10toV11.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV10toV11.java
@@ -6,6 +6,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
+import info.rexs.model.RexsComponent;
+import info.rexs.model.RexsModel;
+import info.rexs.model.RexsRelation;
+import info.rexs.model.RexsRelationRef;
 import info.rexs.schema.RexsSchemaRegistry;
 import info.rexs.schema.constants.RexsAttributeId;
 import info.rexs.schema.constants.RexsComponentType;
@@ -17,10 +21,6 @@ import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 import info.rexs.schema.constants.standard.RexsStandardRelationTypes;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
-import info.rexs.model.RexsComponent;
-import info.rexs.model.RexsModel;
-import info.rexs.model.RexsRelation;
-import info.rexs.model.RexsRelationRef;
 import info.rexs.upgrade.RexsUpgradeException;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.Notification;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.NotificationType;
@@ -207,7 +207,7 @@ public class ModelUpgraderV10toV11 {
 	private void upgradeOrder(RexsComponent parentComponent, RexsRelationType relType, RexsRelationRole parentRole) {
 		List<RexsRelation> sortedRelations = newModel.getRelationsOfType(relType).stream()
 				.filter(rel -> Objects.equals(rel.findComponentIdByRole(parentRole), parentComponent.getId()))
-				.sorted(Comparator.comparing(rel -> rel.getOrder()))
+				.sorted(Comparator.comparing(RexsRelation::getOrder))
 				.toList();
 		for (int i=0; i<sortedRelations.size(); i++) {
 			RexsRelation rel = sortedRelations.get(i);

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV12toV13.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV12toV13.java
@@ -3,15 +3,15 @@ package info.rexs.upgrade.upgraders;
 import java.util.Comparator;
 import java.util.List;
 
+import info.rexs.model.RexsComponent;
+import info.rexs.model.RexsModel;
+import info.rexs.model.RexsRelation;
 import info.rexs.schema.constants.RexsValueType;
 import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
 import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 import info.rexs.schema.constants.standard.RexsStandardRelationTypes;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
-import info.rexs.model.RexsComponent;
-import info.rexs.model.RexsModel;
-import info.rexs.model.RexsRelation;
 import info.rexs.upgrade.RexsUpgradeException;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.ComponentSource;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.Notification;
@@ -107,7 +107,7 @@ public class ModelUpgraderV12toV13 {
 	private void upgradeTools(RexsModel model) {
 		for (RexsComponent gearComp: model.getComponentsOfType(RexsStandardComponentTypes.cylindrical_gear)) {
 			List<RexsRelation> toolRelations = model.getRelations(RexsStandardRelationTypes.ordered_reference, RexsStandardRelationRoles.origin, gearComp.getId()).stream()
-			  .sorted(Comparator.comparingInt(rel -> rel.getOrder()))
+			  .sorted(Comparator.comparingInt(RexsRelation::getOrder))
 			  .toList();
 
 			RexsComponent leftFlankComp = model.getFlankGeometry(gearComp.getId(), RexsStandardRelationRoles.left.getKey());

--- a/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV13toV14.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/ModelUpgraderV13toV14.java
@@ -6,14 +6,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
-import info.rexs.schema.constants.RexsRelationRole;
-import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
-import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
-import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.model.RexsComponent;
 import info.rexs.model.RexsModel;
 import info.rexs.model.RexsRelation;
 import info.rexs.model.RexsRelationRef;
+import info.rexs.schema.constants.RexsRelationRole;
+import info.rexs.schema.constants.standard.RexsStandardAttributeIds;
+import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
+import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.upgrade.RexsUpgradeException;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.AttributeSource;
 import info.rexs.upgrade.upgraders.UpgradeNotifications.ComponentSource;
@@ -69,7 +69,7 @@ public class ModelUpgraderV13toV14 {
 
 	private void checkDuplicateReferences(RexsModel model, RexsRelation rel) {
 		Map<RexsRelationRole, List<RexsRelationRef>> map = rel.getRefs().stream()
-				.collect(Collectors.groupingBy(ref -> ref.getRole()));
+				.collect(Collectors.groupingBy(RexsRelationRef::getRole));
 		boolean hasDuplicate = false;
 		for (Entry<RexsRelationRole, List<RexsRelationRef>> entry: map.entrySet()) {
 			RexsRelationRole role = entry.getKey();

--- a/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeNotifications.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeNotifications.java
@@ -48,7 +48,7 @@ public class UpgradeNotifications {
 		}
 
 		public String getMessageVerbose() {
-			String sourceStr = sources.stream().map(source -> source.toString()).reduce((a,b) -> a+", "+b).orElse("");
+			String sourceStr = sources.stream().map(Object::toString).reduce((a, b) -> a+", "+b).orElse("");
 			return type+": "+message+" ["+sourceStr+"]";
 		}
 	}

--- a/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeNotifications.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeNotifications.java
@@ -7,11 +7,11 @@ import java.util.List;
 
 public class UpgradeNotifications {
 
-	public static enum NotificationType {
+	public enum NotificationType {
 		/** for changes and upgrades that went as expected and specified by the spec */
 		INFO,
 		/**
-		 * for deviations from the spec that can be safely ignored  
+		 * for deviations from the spec that can be safely ignored
 		 * for errors are be fixed automatically and do not require the users attention
 		 * for deprecated things
 		 * */
@@ -53,7 +53,7 @@ public class UpgradeNotifications {
 		}
 	}
 
-	public static interface Source {
+	public interface Source {
 	}
 
 	public static class ComponentSource implements Source {
@@ -112,7 +112,7 @@ public class UpgradeNotifications {
 	public void addAll(Collection<Notification> notification) {
 		notifications.addAll(notification);
 	}
-	
+
 	public List<Notification> getNotifications() {
 		return notifications;
 	}

--- a/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeResolver.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/UpgradeResolver.java
@@ -23,9 +23,9 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import info.rexs.model.RexsModel;
 import info.rexs.schema.constants.RexsVersion;
 import info.rexs.schema.constants.standard.RexsStandardVersions;
-import info.rexs.model.RexsModel;
 import info.rexs.upgrade.RexsUpgradeException;
 
 /**
@@ -132,10 +132,8 @@ public class UpgradeResolver {
 	 * @return
 	 * 				A {@link List} of {@link ModelUpgrader}s.
 	 *
-	 * @throws RexsUpgradeException
-	 * 				If an unexpected error occurs while identifying the upgraders.
 	 */
-	public List<ModelUpgrader> resolve(RexsVersion fromVersion, RexsVersion toVersion) throws RexsUpgradeException {
+	public List<ModelUpgrader> resolve(RexsVersion fromVersion, RexsVersion toVersion) {
 		if (fromVersion == null || toVersion == null)
 			return Collections.emptyList();
 

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
@@ -17,6 +17,7 @@ package info.rexs.upgrade.upgraders.changelog;
 
 import java.io.InputStream;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import info.rexs.schema.constants.RexsVersion;
@@ -151,12 +152,12 @@ public class ChangelogFile {
 		}
 		Object this_fromVersion = getFromVersion();
 		Object other_fromVersion = other.getFromVersion();
-		if (this_fromVersion == null ? other_fromVersion != null : !this_fromVersion.equals(other_fromVersion)) {
+		if (!Objects.equals(this_fromVersion, other_fromVersion)) {
 			return false;
 		}
 		Object this_toVersion = getToVersion();
 		Object other_toVersion = other.getToVersion();
-		return this_toVersion == null ? other_toVersion == null : this_toVersion.equals(other_toVersion);
+		return Objects.equals(this_toVersion, other_toVersion);
 	}
 
 	protected boolean canEqual(Object other) {

--- a/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
+++ b/api/src/main/java/info/rexs/upgrade/upgraders/changelog/ChangelogFile.java
@@ -143,10 +143,9 @@ public class ChangelogFile {
 		if (o == this) {
 			return true;
 		}
-		if (!(o instanceof ChangelogFile)) {
+		if (!(o instanceof ChangelogFile other)) {
 			return false;
 		}
-		ChangelogFile other = (ChangelogFile)o;
 		if (!other.canEqual(this)) {
 			return false;
 		}

--- a/api/src/main/java/info/rexs/validation/DefaultRexsFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/DefaultRexsFileValidator.java
@@ -22,16 +22,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
-
-import org.xml.sax.ErrorHandler;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import info.rexs.io.FileResource;
 import info.rexs.io.Resource;
@@ -40,6 +35,9 @@ import info.rexs.io.RexsIoFormat;
 import info.rexs.io.zip.RexsZipFileReader;
 import info.rexs.model.RexsModel;
 import info.rexs.xsd.RexsXsd;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * This implementation of {@link IRexsFileValidator} validates the basic structure of a REXS file.
@@ -164,8 +162,7 @@ public class DefaultRexsFileValidator implements IRexsFileValidator {
 		private List<String> warningMessages = new ArrayList<>();
 
 		@Override
-		public void error(SAXParseException ex) throws SAXException
-		{
+		public void error(SAXParseException ex) {
 			errorMessages.add(createExceptionMessage(ex));
 		}
 
@@ -178,14 +175,12 @@ public class DefaultRexsFileValidator implements IRexsFileValidator {
 		}
 
 		@Override
-		public void fatalError(SAXParseException ex) throws SAXException
-		{
+		public void fatalError(SAXParseException ex) {
 			errorMessages.add(createExceptionMessage(ex));
 		}
 
 		@Override
-		public void warning(SAXParseException ex) throws SAXException
-		{
+		public void warning(SAXParseException ex) {
 			warningMessages.add(createExceptionMessage(ex));
 		}
 

--- a/api/src/main/java/info/rexs/validation/IRexsAttributeValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsAttributeValidator.java
@@ -36,5 +36,5 @@ public interface IRexsAttributeValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(RexsAttribute rexsAttribute, RexsComponent rexsComponent);
+	RexsValidationResult validate(RexsAttribute rexsAttribute, RexsComponent rexsComponent);
 }

--- a/api/src/main/java/info/rexs/validation/IRexsComponentValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsComponentValidator.java
@@ -33,7 +33,7 @@ public interface IRexsComponentValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(RexsComponent rexsComponent);
+	RexsValidationResult validate(RexsComponent rexsComponent);
 
 	/**
 	 * Creates a new validator for the attributes of the component.
@@ -41,5 +41,5 @@ public interface IRexsComponentValidator {
 	 * @return
 	 * 				The attribute validator as {@link IRexsAttributeValidator}.
 	 */
-	public IRexsAttributeValidator createAttributeValidator();
+	IRexsAttributeValidator createAttributeValidator();
 }

--- a/api/src/main/java/info/rexs/validation/IRexsFileValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsFileValidator.java
@@ -36,7 +36,7 @@ public interface IRexsFileValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(Resource rexsFileResource);
+	RexsValidationResult validate(Resource rexsFileResource);
 
 	/**
 	 * Validates a REXS file for the given {@link Path} to the REXS file and returns the validation result.
@@ -47,7 +47,7 @@ public interface IRexsFileValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(Path pathToRexsFile);
+	RexsValidationResult validate(Path pathToRexsFile);
 
 	/**
 	 * Validates a REXS file for the given REXS {@link File} and returns the validation result.
@@ -58,7 +58,7 @@ public interface IRexsFileValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(File rexsFile);
+	RexsValidationResult validate(File rexsFile);
 
 	/**
 	 * Validates a REXS file for the given path to the REXS file as {@link String} and returns the validation result.
@@ -69,7 +69,7 @@ public interface IRexsFileValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(String pathToRexsFile);
+	RexsValidationResult validate(String pathToRexsFile);
 
 	/**
 	 * Creates a new validator for the model of the REXS file.
@@ -77,5 +77,5 @@ public interface IRexsFileValidator {
 	 * @return
 	 * 				The model validator as {@link IRexsModelValidator}.
 	 */
-	public IRexsModelValidator createModelValidator();
+	IRexsModelValidator createModelValidator();
 }

--- a/api/src/main/java/info/rexs/validation/IRexsModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsModelValidator.java
@@ -33,7 +33,7 @@ public interface IRexsModelValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(RexsModel rexsModel);
+	RexsValidationResult validate(RexsModel rexsModel);
 
 	/**
 	 * Creates a new validator for the components of the REXS file.
@@ -41,7 +41,7 @@ public interface IRexsModelValidator {
 	 * @return
 	 * 				The component validator as {@link IRexsComponentValidator}.
 	 */
-	public IRexsComponentValidator createComponentValidator();
+	IRexsComponentValidator createComponentValidator();
 
 	/**
 	 * Creates a new validator for the relations of the REXS file.

--- a/api/src/main/java/info/rexs/validation/IRexsRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/IRexsRelationValidator.java
@@ -35,5 +35,5 @@ public interface IRexsRelationValidator {
 	 * @return
 	 * 				The validation result as {@link RexsValidationResult}.
 	 */
-	public RexsValidationResult validate(RexsRelation rexsRelation, RexsModel rexsModel);
+	RexsValidationResult validate(RexsRelation rexsRelation, RexsModel rexsModel);
 }

--- a/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticModelValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticModelValidator.java
@@ -19,15 +19,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import info.rexs.model.RexsComponent;
+import info.rexs.model.RexsModel;
+import info.rexs.model.RexsRelation;
 import info.rexs.schema.IRexsSchemaRegistry;
 import info.rexs.schema.constants.RexsComponentType;
 import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 import info.rexs.schema.constants.standard.RexsStandardRelationTypes;
 import info.rexs.schema.jaxb.AllowedCombinationRole;
-import info.rexs.model.RexsComponent;
-import info.rexs.model.RexsModel;
-import info.rexs.model.RexsRelation;
 
 public class RexsModellingGuidelineQuasistaticModelValidator extends RexsStandardModelValidator {
 
@@ -122,7 +122,7 @@ public class RexsModellingGuidelineQuasistaticModelValidator extends RexsStandar
 
 				for (Integer pinId : pinShaftIds) {
 					List<RexsRelation> sideRelations = rexsModel.getRelations(RexsStandardRelationTypes.side, RexsStandardRelationRoles.inner_part, pinId);
-					if (!atLeastOneIdIsContainedInRelations(sidePlates.stream().map(c -> c.getId()).toList(), sideRelations))
+					if (!atLeastOneIdIsContainedInRelations(sidePlates.stream().map(RexsComponent::getId).toList(), sideRelations))
 						validationResult.addError(RexsValidationResultMessageKey.GUIDELINE_QUASISTATIC_SIDE_PLATE_MISSING_PIN_COUPLING, rexsModel.getComponent(pinId).toString());
 				}
 

--- a/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsModellingGuidelineQuasistaticRelationValidator.java
@@ -3,11 +3,12 @@ package info.rexs.validation;
 import java.util.ArrayList;
 import java.util.List;
 
+import info.rexs.model.RexsModel;
+import info.rexs.model.RexsRelation;
+import info.rexs.model.RexsRelationRef;
 import info.rexs.schema.IRexsSchemaRegistry;
 import info.rexs.schema.constants.RexsRelationRole;
 import info.rexs.schema.constants.RexsVersion;
-import info.rexs.model.RexsModel;
-import info.rexs.model.RexsRelation;
 
 public class RexsModellingGuidelineQuasistaticRelationValidator extends RexsStandardRelationValidator {
 
@@ -29,10 +30,10 @@ public class RexsModellingGuidelineQuasistaticRelationValidator extends RexsStan
 		int numRefs = rexsRelation.getRefs().size();
 		int numRoles = rolesOfRelationType.size();
 		if (numRefs!=numRoles) {
-			List<RexsRelationRole> rolesInRelation = rexsRelation.getRefs().stream().map(r -> r.getRole()).toList();
+			List<RexsRelationRole> rolesInRelation = rexsRelation.getRefs().stream().map(RexsRelationRef::getRole).toList();
 			List<String> messageList = new ArrayList<>();
 			messageList.add(String.valueOf(rexsRelation.getId()));
-			messageList.addAll(rolesOfRelationType.stream().filter(r -> !rolesInRelation.contains(r)).map(r -> r.getKey()).toList());
+			messageList.addAll(rolesOfRelationType.stream().filter(r -> !rolesInRelation.contains(r)).map(RexsRelationRole::getKey).toList());
 			String[] additionalMessages = new String[messageList.size()];
 			for (int i=0; i<messageList.size(); i++)
 				additionalMessages[i] = messageList.get(i);

--- a/api/src/main/java/info/rexs/validation/RexsStandardRelationValidator.java
+++ b/api/src/main/java/info/rexs/validation/RexsStandardRelationValidator.java
@@ -21,15 +21,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import info.rexs.schema.RexsSchemaRegistry;
+import info.rexs.model.RexsModel;
+import info.rexs.model.RexsRelation;
+import info.rexs.model.RexsRelationRef;
 import info.rexs.schema.IRexsSchemaRegistry;
+import info.rexs.schema.RexsSchemaRegistry;
 import info.rexs.schema.constants.RexsComponentType;
 import info.rexs.schema.constants.RexsRelationRole;
 import info.rexs.schema.constants.RexsVersion;
 import info.rexs.schema.jaxb.AllowedCombinationRole;
-import info.rexs.model.RexsModel;
-import info.rexs.model.RexsRelation;
-import info.rexs.model.RexsRelationRef;
 
 /**
  * This implementation of {@link IRexsRelationValidator} validates the basic structure of a REXS relation
@@ -108,7 +108,7 @@ public class RexsStandardRelationValidator extends DefaultRexsRelationValidator 
 
 	private boolean allowedCombinationMatches(List<AllowedCombinationRole> allowedCombination, Map<RexsRelationRole, RexsComponentType> mapRoleToComponentType) {
 		for (RexsRelationRole role : mapRoleToComponentType.keySet()) {
-			Optional<String> allowedComponentTypeForRole = allowedCombination.stream().filter(a -> a.getRoleId().equals(role.getKey())).map(a -> a.getComponentId()).findFirst();
+			Optional<String> allowedComponentTypeForRole = allowedCombination.stream().filter(a -> a.getRoleId().equals(role.getKey())).map(AllowedCombinationRole::getComponentId).findFirst();
 			if (allowedComponentTypeForRole.isEmpty() || !allowedComponentTypeForRole.get().equals(mapRoleToComponentType.get(role).getId()))
 				return false;
 		}

--- a/api/src/main/java/info/rexs/validation/RexsValidationResultMessageKey.java
+++ b/api/src/main/java/info/rexs/validation/RexsValidationResultMessageKey.java
@@ -71,7 +71,7 @@ public enum RexsValidationResultMessageKey {
 	/** The default message of the message key. */
 	private String defaultMessage;
 
-	private RexsValidationResultMessageKey(String defaultMessage) {
+	RexsValidationResultMessageKey(String defaultMessage) {
 		this.defaultMessage = defaultMessage;
 	}
 

--- a/api/src/main/java/info/rexs/xsd/RexsXsd.java
+++ b/api/src/main/java/info/rexs/xsd/RexsXsd.java
@@ -47,7 +47,7 @@ public enum RexsXsd {
 
 	private String filename;
 
-	private RexsXsd(String filename) {
+	RexsXsd(String filename) {
 		this.filename = filename;
 	}
 

--- a/api/src/test/java/info/rexs/io/RexsFileUpgraderTest.java
+++ b/api/src/test/java/info/rexs/io/RexsFileUpgraderTest.java
@@ -35,7 +35,7 @@ public class RexsFileUpgraderTest {
 		rexsFileUpgrader.upgrade();
 
 		assertThat(rexsOutputFilePath).exists();
-		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0L);
 	}
 
 	@Test
@@ -47,7 +47,7 @@ public class RexsFileUpgraderTest {
 		rexsFileUpgrader.upgrade();
 
 		assertThat(rexsOutputFile).exists();
-		assertThat(rexsOutputFile.length()).isGreaterThan(0l);
+		assertThat(rexsOutputFile.length()).isGreaterThan(0L);
 	}
 
 	@Test
@@ -60,6 +60,6 @@ public class RexsFileUpgraderTest {
 
 		Path rexsOutputFilePath = Paths.get(rexsOutputFileStringPath);
 		assertThat(rexsOutputFilePath).exists();
-		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0L);
 	}
 }

--- a/api/src/test/java/info/rexs/io/RexsFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/RexsFileWriterTest.java
@@ -57,7 +57,7 @@ public class RexsFileWriterTest {
 		writer.write(aRexsModelToWrite);
 
 		assertThat(rexsTargetFile).exists();
-		assertThat(rexsTargetFile.length()).isGreaterThan(0l);
+		assertThat(rexsTargetFile.length()).isGreaterThan(0L);
 	}
 
 	@Test
@@ -98,6 +98,6 @@ public class RexsFileWriterTest {
 
 		Path rexsTargetFilePath = Paths.get(rexsTargetFileStringPath);
 		assertThat(rexsTargetFilePath).exists();
-		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0L);
 	}
 }

--- a/api/src/test/java/info/rexs/io/json/RexsJsonFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/json/RexsJsonFileWriterTest.java
@@ -84,6 +84,6 @@ public class RexsJsonFileWriterTest {
 
 		Path rexsOutputFilePath = Paths.get(rexsOutputFileStringPath);
 		assertThat(rexsOutputFilePath).exists();
-		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsOutputFilePath)).isGreaterThan(0L);
 	}
 }

--- a/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/xml/RexsXmlFileReaderTest.java
@@ -27,16 +27,15 @@ import java.nio.file.StandardOpenOption;
 
 import org.junit.Test;
 
-import info.rexs.schema.constants.RexsVersion;
-import info.rexs.schema.constants.standard.RexsStandardVersions;
 import info.rexs.io.RexsIoException;
 import info.rexs.model.RexsModel;
 import info.rexs.model.jaxb.Model;
+import info.rexs.schema.constants.standard.RexsStandardVersions;
 
 public class RexsXmlFileReaderTest {
 
 	@Test
-	public void readRawModel_nonExistingFileThrowsFileNotFoundException() throws Exception {
+	public void readRawModel_nonExistingFileThrowsFileNotFoundException() {
 		Path nonExistingFilePath = Paths.get("path/to/non/existing/file");
 
 		assertThatExceptionOfType(RexsIoException.class).isThrownBy(() -> {

--- a/api/src/test/java/info/rexs/io/xml/RexsXmlFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/xml/RexsXmlFileWriterTest.java
@@ -51,7 +51,7 @@ public class RexsXmlFileWriterTest {
 		writer.writeRawModel(aRexsModelToWriteXml);
 
 		assertThat(nonExistingFilePath).exists();
-		assertThat(Files.size(nonExistingFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(nonExistingFilePath)).isGreaterThan(0L);
 	}
 
 	@Test
@@ -75,7 +75,7 @@ public class RexsXmlFileWriterTest {
 		writer.writeRawModel(aRexsModelToWriteXml);
 
 		assertThat(existingFilePath).exists();
-		assertThat(Files.size(existingFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(existingFilePath)).isGreaterThan(0L);
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class RexsXmlFileWriterTest {
 		writer.write(aRexsModelToWrite);
 
 		assertThat(rexsTargetFile).exists();
-		assertThat(rexsTargetFile.length()).isGreaterThan(0l);
+		assertThat(rexsTargetFile.length()).isGreaterThan(0L);
 	}
 
 	@Test
@@ -108,6 +108,6 @@ public class RexsXmlFileWriterTest {
 
 		Path rexsTargetFilePath = Paths.get(rexsTargetFileStringPath);
 		assertThat(rexsTargetFilePath).exists();
-		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0L);
 	}
 }

--- a/api/src/test/java/info/rexs/io/zip/RexsZipFileReaderTest.java
+++ b/api/src/test/java/info/rexs/io/zip/RexsZipFileReaderTest.java
@@ -30,7 +30,7 @@ import info.rexs.model.RexsModel;
 public class RexsZipFileReaderTest {
 
 	@Test
-	public void read_nonExistingFileThrowsFileNotFoundException() throws Exception {
+	public void read_nonExistingFileThrowsFileNotFoundException() {
 		Path nonExistingFilePath = Paths.get("path/to/non/existing/file");
 
 		assertThatExceptionOfType(RexsIoException.class).isThrownBy(() -> {

--- a/api/src/test/java/info/rexs/io/zip/RexsZipFileWriterTest.java
+++ b/api/src/test/java/info/rexs/io/zip/RexsZipFileWriterTest.java
@@ -46,7 +46,7 @@ public class RexsZipFileWriterTest {
 		writer.write(aRexsModelToWrite);
 
 		assertThat(nonExistingFilePath).exists();
-		assertThat(Files.size(nonExistingFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(nonExistingFilePath)).isGreaterThan(0L);
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class RexsZipFileWriterTest {
 		writer.write(aRexsModelToWrite);
 
 		assertThat(existingFilePath).exists();
-		assertThat(Files.size(existingFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(existingFilePath)).isGreaterThan(0L);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class RexsZipFileWriterTest {
 		writer.write(aRexsModelToWrite);
 
 		assertThat(rexsTargetFile).exists();
-		assertThat(rexsTargetFile.length()).isGreaterThan(0l);
+		assertThat(rexsTargetFile.length()).isGreaterThan(0L);
 	}
 
 	@Test
@@ -90,6 +90,6 @@ public class RexsZipFileWriterTest {
 
 		Path rexsTargetFilePath = Paths.get(rexsTargetFileStringPath);
 		assertThat(rexsTargetFilePath).exists();
-		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0l);
+		assertThat(Files.size(rexsTargetFilePath)).isGreaterThan(0L);
 	}
 }

--- a/api/src/test/java/info/rexs/model/RexsAttributeTest.java
+++ b/api/src/test/java/info/rexs/model/RexsAttributeTest.java
@@ -26,7 +26,7 @@ import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 public class RexsAttributeTest {
 
 	@Test
-	public void attributeIdConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void attributeIdConstructor_getterMatchesValuePassedToConstructor() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 
 		assertThat(rexsAttribute.getAttributeId()).isEqualTo(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
@@ -34,7 +34,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void attributeIdConstructor_originIdCreated() throws Exception {
+	public void attributeIdConstructor_originIdCreated() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 
 		assertThat(rexsAttribute.getOriginAttributeId()).isNotNull();
@@ -42,14 +42,14 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_emptyValueReturnsFalse() throws Exception {
+	public void hasValue_emptyValueReturnsFalse() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 
 		assertThat(rexsAttribute.hasValue()).isFalse();
 	}
 
 	@Test
-	public void hasValue_emptyStringValueReturnsFalse() throws Exception {
+	public void hasValue_emptyStringValueReturnsFalse() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringValue("");
 
@@ -57,7 +57,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_setStringValueReturnsTrue() throws Exception {
+	public void hasValue_setStringValueReturnsTrue() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringValue("foo_bar");
 
@@ -65,7 +65,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_emptyStringArrayValueReturnsFalse() throws Exception {
+	public void hasValue_emptyStringArrayValueReturnsFalse() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringArrayValue(new String[] {});
 
@@ -73,7 +73,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_setStringArrayValueReturnsTrue() throws Exception {
+	public void hasValue_setStringArrayValueReturnsTrue() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringArrayValue(new String[] {"foo", "bar"});
 
@@ -81,7 +81,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_emptyStringMatrixValueReturnsFalse() throws Exception {
+	public void hasValue_emptyStringMatrixValueReturnsFalse() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 
 		rexsAttribute.setStringMatrixValue(new String[][] {});
@@ -92,7 +92,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void hasValue_setStringMatrixValueReturnsTrue() throws Exception {
+	public void hasValue_setStringMatrixValueReturnsTrue() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringMatrixValue(new String[][] {{"foo"}, {"bar"}});
 
@@ -100,7 +100,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getStringValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getStringValue();
@@ -109,7 +109,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringValue_setValueIsReturned() throws Exception {
+	public void getStringValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringValue("foo_bar");
 
@@ -117,7 +117,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getBooleanValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getBooleanValue();
@@ -126,7 +126,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanValue_setValueIsReturned() throws Exception {
+	public void getBooleanValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 
 		rexsAttribute.setBooleanValue(Boolean.TRUE);
@@ -137,7 +137,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getIntegerValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getIntegerValue();
@@ -146,7 +146,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerValue_setValueIsReturned() throws Exception {
+	public void getIntegerValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setIntegerValue(42);
 
@@ -154,7 +154,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getDoubleValue(RexsStandardUnitIds.hertz);
@@ -163,7 +163,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleValue_setValueButWrongUnitThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleValue_setValueButWrongUnitThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.setDoubleValue(8.24);
@@ -173,7 +173,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleValue_setValueIsReturned() throws Exception {
+	public void getDoubleValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setDoubleValue(8.24);
 
@@ -181,7 +181,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringArrayValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getStringArrayValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getStringArrayValue();
@@ -190,7 +190,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringArrayValue_setValueIsReturned() throws Exception {
+	public void getStringArrayValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringArrayValue(new String[] {"foo", "bar"});
 
@@ -198,7 +198,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanArrayValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getBooleanArrayValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getBooleanArrayValue();
@@ -207,7 +207,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanArrayValue_setValueIsReturned() throws Exception {
+	public void getBooleanArrayValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setBooleanArrayValue(new Boolean[] {Boolean.FALSE, Boolean.TRUE});
 
@@ -215,7 +215,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerArrayValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getIntegerArrayValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getIntegerArrayValue();
@@ -224,7 +224,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerArrayValue_setValueIsReturned() throws Exception {
+	public void getIntegerArrayValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setIntegerArrayValue(new Integer[] {42, 23});
 
@@ -232,7 +232,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleArrayValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleArrayValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getDoubleArrayValue(RexsStandardUnitIds.hertz);
@@ -241,7 +241,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleArrayValue_setValueButWrongUnitThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleArrayValue_setValueButWrongUnitThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.setDoubleArrayValue(new Double[] {8.24, 23.33});
@@ -251,7 +251,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleArrayValue_setValueIsReturned() throws Exception {
+	public void getDoubleArrayValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setDoubleArrayValue(new Double[] {8.24, 23.33});
 
@@ -259,7 +259,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringMatrixValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getStringMatrixValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getStringMatrixValue();
@@ -268,7 +268,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getStringMatrixValue_setValueIsReturned() throws Exception {
+	public void getStringMatrixValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringMatrixValue(new String[][] {{"foo"}, {"bar"}});
 
@@ -276,7 +276,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanMatrixValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getBooleanMatrixValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getBooleanMatrixValue();
@@ -285,7 +285,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getBooleanMatrixValue_setValueIsReturned() throws Exception {
+	public void getBooleanMatrixValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setBooleanMatrixValue(new Boolean[][] {{Boolean.FALSE}, {Boolean.TRUE}});
 
@@ -293,7 +293,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerMatrixValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getIntegerMatrixValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getIntegerMatrixValue();
@@ -302,7 +302,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getIntegerMatrixValue_setValueIsReturned() throws Exception {
+	public void getIntegerMatrixValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setIntegerMatrixValue(new Integer[][] {{42}, {23}});
 
@@ -310,7 +310,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleMatrixValue_emptyValueThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleMatrixValue_emptyValueThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.getDoubleMatrixValue(RexsStandardUnitIds.hertz);
@@ -319,7 +319,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleMatrixValue_setValueButWrongUnitThrowsRexsModelAccessException() throws Exception {
+	public void getDoubleMatrixValue_setValueButWrongUnitThrowsRexsModelAccessException() {
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
 			RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 			rexsAttribute.setDoubleMatrixValue(new Double[][] {{8.24}, {23.33}});
@@ -329,7 +329,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void getDoubleMatrixValue_setValueIsReturned() throws Exception {
+	public void getDoubleMatrixValue_setValueIsReturned() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setDoubleMatrixValue(new Double[][] {{8.24}, {23.33}});
 
@@ -337,7 +337,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void setStringArrayValue_nullValueDeletesPreviousValue() throws Exception {
+	public void setStringArrayValue_nullValueDeletesPreviousValue() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringArrayValue(new String[] {"foo", "bar"});
 
@@ -350,7 +350,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void setStringArrayValue_nullElementConvertsToEmptyString() throws Exception {
+	public void setStringArrayValue_nullElementConvertsToEmptyString() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringArrayValue(new String[] {"foo", null, "bar"});
 
@@ -358,7 +358,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void setStringMatrixValue_nullValueDeletesPreviousValue() throws Exception {
+	public void setStringMatrixValue_nullValueDeletesPreviousValue() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringMatrixValue(new String[][] {{"foo"}, {"bar"}});
 
@@ -371,7 +371,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void setStringMatrixValue_nullElementConvertsToEmptyString() throws Exception {
+	public void setStringMatrixValue_nullElementConvertsToEmptyString() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringMatrixValue(new String[][] {{"foo", null}, {"bar", ""}});
 
@@ -379,7 +379,7 @@ public class RexsAttributeTest {
 	}
 
 	@Test
-	public void setStringMatrixValue_nullMatrixRowConvertsToNullElements() throws Exception {
+	public void setStringMatrixValue_nullMatrixRowConvertsToNullElements() {
 		RexsAttribute rexsAttribute = new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_rolling_element);
 		rexsAttribute.setStringMatrixValue(new String[][] {{"foo", "bar"}, null});
 

--- a/api/src/test/java/info/rexs/model/RexsAttributeTest.java
+++ b/api/src/test/java/info/rexs/model/RexsAttributeTest.java
@@ -343,7 +343,7 @@ public class RexsAttributeTest {
 
 		rexsAttribute.setStringArrayValue(null);
 
-		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> rexsAttribute.getStringArrayValue())
+		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(rexsAttribute::getStringArrayValue)
 		.withMessageStartingWith("value cannot be null for attribute");
 	}
 
@@ -362,7 +362,7 @@ public class RexsAttributeTest {
 
 		rexsAttribute.setStringMatrixValue(null);
 
-		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> rexsAttribute.getStringMatrixValue())
+		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(rexsAttribute::getStringMatrixValue)
 		.withMessageStartingWith("value cannot be null for attribute");
 	}
 

--- a/api/src/test/java/info/rexs/model/RexsAttributeTest.java
+++ b/api/src/test/java/info/rexs/model/RexsAttributeTest.java
@@ -343,9 +343,7 @@ public class RexsAttributeTest {
 
 		rexsAttribute.setStringArrayValue(null);
 
-		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
-			rexsAttribute.getStringArrayValue();
-		})
+		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> rexsAttribute.getStringArrayValue())
 		.withMessageStartingWith("value cannot be null for attribute");
 	}
 
@@ -364,9 +362,7 @@ public class RexsAttributeTest {
 
 		rexsAttribute.setStringMatrixValue(null);
 
-		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
-			rexsAttribute.getStringMatrixValue();
-		})
+		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> rexsAttribute.getStringMatrixValue())
 		.withMessageStartingWith("value cannot be null for attribute");
 	}
 

--- a/api/src/test/java/info/rexs/model/RexsComponentTest.java
+++ b/api/src/test/java/info/rexs/model/RexsComponentTest.java
@@ -27,7 +27,7 @@ import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 public class RexsComponentTest {
 
 	@Test
-	public void componentConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void componentConstructor_getterMatchesValuePassedToConstructor() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, "bar");
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring));
 
@@ -39,21 +39,21 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void getName_returnsEmptyStringIfNull() throws Exception {
+	public void getName_returnsEmptyStringIfNull() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 
 		assertThat(rexsComponent.getName()).isEqualTo("");
 	}
 
 	@Test
-	public void hasAttribute_attributeNotInComponentReturnsFalse() throws Exception {
+	public void hasAttribute_attributeNotInComponentReturnsFalse() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 
 		assertThat(rexsComponent.hasAttribute(RexsStandardAttributeIds.account_for_gravity)).isFalse();
 	}
 
 	@Test
-	public void hasAttribute_attributeInComponentReturnsTrue() throws Exception {
+	public void hasAttribute_attributeInComponentReturnsTrue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring));
 
@@ -61,7 +61,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void getAttribute_attributeNotInComponentReturnsNull() throws Exception {
+	public void getAttribute_attributeNotInComponentReturnsNull() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 
 		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
@@ -70,7 +70,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void getAttribute_attributeInComponentReturnsAttribute() throws Exception {
+	public void getAttribute_attributeInComponentReturnsAttribute() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring));
 
@@ -81,7 +81,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_replacesExistingAttribute() throws Exception {
+	public void addAttribute_replacesExistingAttribute() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.number_of_gears));
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.number_of_gears));
@@ -95,7 +95,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_addsNonExistingAttribute() throws Exception {
+	public void addAttribute_addsNonExistingAttribute() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.number_of_teeth));
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.number_of_gears));
@@ -106,7 +106,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithStringValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithStringValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, "foo_bar");
 
@@ -114,7 +114,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithBooleanValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithBooleanValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, Boolean.TRUE);
 
@@ -122,7 +122,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithIntegerValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithIntegerValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, 42);
 
@@ -130,7 +130,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithFloatingPointValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithFloatingPointValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.addendum_basic_profile, 8.15);
 
@@ -138,7 +138,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithStringArrayValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithStringArrayValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new String[] {"foo", "bar"});
 
@@ -146,7 +146,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithBooleanArrayValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithBooleanArrayValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new Boolean[] {Boolean.TRUE, Boolean.FALSE});
 
@@ -154,7 +154,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithIntegerArrayValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithIntegerArrayValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new Integer[] {8, 15});
 
@@ -162,7 +162,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithFloatingPointArrayValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithFloatingPointArrayValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring, new Double[] {23.33, 24.8});
 
@@ -170,7 +170,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithStringMatrixValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithStringMatrixValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new String[][] {{"foo"}, {"bar"}});
 
@@ -178,7 +178,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithBooleanMatrixValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithBooleanMatrixValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new Boolean[][] {{Boolean.TRUE}, {Boolean.FALSE}});
 
@@ -186,7 +186,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithIntegerMatrixValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithIntegerMatrixValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.account_for_gravity, new Integer[][] {{8}, {15}});
 
@@ -194,7 +194,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void addAttribute_createAndAddsAttributeWithFloatingPointMatrixValue() throws Exception {
+	public void addAttribute_createAndAddsAttributeWithFloatingPointMatrixValue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(RexsStandardAttributeIds.addendum_modification, new Double[][] {{23.33}, {24.8}});
 
@@ -202,7 +202,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void changeComponentId_changesIdOfComponent() throws Exception {
+	public void changeComponentId_changesIdOfComponent() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.changeComponentId(2);
 
@@ -210,7 +210,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void compareTo_comparesById() throws Exception {
+	public void compareTo_comparesById() {
 		RexsComponent rexsComponent23 = new RexsComponent(23, RexsStandardComponentTypes.coupling, null);
 		RexsComponent rexsComponent42 = new RexsComponent(42, RexsStandardComponentTypes.coupling, null);
 
@@ -221,7 +221,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void deleteAttribute_notIncludedAttributeIsIgnored() throws Exception {
+	public void deleteAttribute_notIncludedAttributeIsIgnored() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring));
 		rexsComponent.deleteAttribute(RexsStandardAttributeIds.number_of_gears);
@@ -231,7 +231,7 @@ public class RexsComponentTest {
 	}
 
 	@Test
-	public void deleteAttribute_deletesIncludedAttribute() throws Exception {
+	public void deleteAttribute_deletesIncludedAttribute() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 		rexsComponent.addAttribute(new RexsAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring));
 		rexsComponent.deleteAttribute(RexsStandardAttributeIds.overrolling_frequency_inner_ring);

--- a/api/src/test/java/info/rexs/model/RexsComponentTest.java
+++ b/api/src/test/java/info/rexs/model/RexsComponentTest.java
@@ -64,9 +64,7 @@ public class RexsComponentTest {
 	public void getAttribute_attributeNotInComponentReturnsNull() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.coupling, null);
 
-		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> {
-			rexsComponent.getAttribute(RexsStandardAttributeIds.account_for_gravity);
-		}).withMessage("attribute 'account_for_gravity' not found!");
+		assertThatExceptionOfType(RexsModelAccessException.class).isThrownBy(() -> rexsComponent.getAttribute(RexsStandardAttributeIds.account_for_gravity)).withMessage("attribute 'account_for_gravity' not found!");
 	}
 
 	@Test

--- a/api/src/test/java/info/rexs/model/RexsModelAccessExceptionTest.java
+++ b/api/src/test/java/info/rexs/model/RexsModelAccessExceptionTest.java
@@ -27,7 +27,7 @@ import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 public class RexsModelAccessExceptionTest {
 
 	@Test
-	public void messageConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void messageConstructor_getterMatchesValuePassedToConstructor() {
 		String message = UUID.randomUUID().toString();
 		RexsModelAccessException ex = new RexsModelAccessException(message);
 
@@ -37,7 +37,7 @@ public class RexsModelAccessExceptionTest {
 	}
 
 	@Test
-	public void messageAndCauseConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void messageAndCauseConstructor_getterMatchesValuePassedToConstructor() {
 		Exception cause = new Exception("foo");
 		RexsModelAccessException ex = new RexsModelAccessException("bar", cause);
 
@@ -48,7 +48,7 @@ public class RexsModelAccessExceptionTest {
 	}
 
 	@Test
-	public void componentAndmessageConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void componentAndmessageConstructor_getterMatchesValuePassedToConstructor() {
 		Integer id = 15;
 		RexsComponentType type = RexsStandardComponentTypes.UNKNOWN;
 		String name = "SampleComponent";
@@ -62,7 +62,7 @@ public class RexsModelAccessExceptionTest {
 	}
 
 	@Test
-	public void componentAndmessageAndCauseConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void componentAndmessageAndCauseConstructor_getterMatchesValuePassedToConstructor() {
 		Integer id = 15;
 		RexsComponentType type = RexsStandardComponentTypes.UNKNOWN;
 		String name = "SampleComponent";

--- a/api/src/test/java/info/rexs/model/RexsRelationRefTest.java
+++ b/api/src/test/java/info/rexs/model/RexsRelationRefTest.java
@@ -24,7 +24,7 @@ import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 public class RexsRelationRefTest {
 
 	@Test
-	public void integerStringConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void integerStringConstructor_getterMatchesValuePassedToConstructor() {
 		RexsRelationRef rexsRelationData = new RexsRelationRef(42, RexsStandardRelationRoles.UNKNOWN, "foo bar");
 
 		assertThat(rexsRelationData.getId()).isEqualTo(42);

--- a/api/src/test/java/info/rexs/model/RexsSubModelTest.java
+++ b/api/src/test/java/info/rexs/model/RexsSubModelTest.java
@@ -24,7 +24,7 @@ import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 public class RexsSubModelTest {
 
 	@Test
-	public void integerConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void integerConstructor_getterMatchesValuePassedToConstructor() {
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
 
 		assertThat(rexsSubModel.getId()).isEqualTo(41);
@@ -32,7 +32,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void loadCaseConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void loadCaseConstructor_getterMatchesValuePassedToConstructor() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.UNKNOWN, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
@@ -44,7 +44,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void accumulationConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void accumulationConstructor_getterMatchesValuePassedToConstructor() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.UNKNOWN, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel();
@@ -56,7 +56,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void accumulationConstructor_nullParameterDoesNotCrash() throws Exception {
+	public void accumulationConstructor_nullParameterDoesNotCrash() {
 		RexsSubModel rexsSubModel = new RexsSubModel();
 
 		assertThat(rexsSubModel.getId()).isNull();
@@ -65,7 +65,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void hasComponent_componentNotInSubModelReturnsFalse() throws Exception {
+	public void hasComponent_componentNotInSubModelReturnsFalse() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.UNKNOWN, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
@@ -75,7 +75,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void hasComponent_componentInSubModelReturnsTrue() throws Exception {
+	public void hasComponent_componentInSubModelReturnsTrue() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.UNKNOWN, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
@@ -85,7 +85,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void getComponent_componentNotInSubModelReturnsNull() throws Exception {
+	public void getComponent_componentNotInSubModelReturnsNull() {
 		RexsComponent rexsComponent = new RexsComponent(1, RexsStandardComponentTypes.UNKNOWN, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
@@ -95,7 +95,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void getComponent_componentInSubModelReturnsComponent() throws Exception {
+	public void getComponent_componentInSubModelReturnsComponent() {
 		RexsComponent rexsComponent1 = new RexsComponent(1, RexsStandardComponentTypes.cylindrical_gear, "Foo");
 
 		RexsSubModel rexsSubModel = new RexsSubModel(41);
@@ -108,7 +108,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void changeComponentId_nonExistingComponentIdIgnoresMethodCall() throws Exception {
+	public void changeComponentId_nonExistingComponentIdIgnoresMethodCall() {
 		RexsComponent rexsComponent1 = new RexsComponent(1, RexsStandardComponentTypes.cylindrical_gear, "Foo");
 		RexsComponent rexsComponent2 = new RexsComponent(2, RexsStandardComponentTypes.bevel_gear, "Bar");
 
@@ -124,7 +124,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void changeComponentId_changesIdOfComponent() throws Exception {
+	public void changeComponentId_changesIdOfComponent() {
 		RexsComponent rexsComponent1 = new RexsComponent(1, RexsStandardComponentTypes.cylindrical_gear, "Foo");
 		RexsComponent rexsComponent2 = new RexsComponent(2, RexsStandardComponentTypes.bevel_gear, "Bar");
 
@@ -139,7 +139,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void compareTo_accumulationIsAlwaysGreaterThanAnyOtherLoadCase() throws Exception {
+	public void compareTo_accumulationIsAlwaysGreaterThanAnyOtherLoadCase() {
 		RexsSubModel rexsSubModelAccumulation = new RexsSubModel();
 		RexsSubModel rexsSubModelLoadCase1 = new RexsSubModel(1);
 		RexsSubModel rexsSubModelLoadCase24 = new RexsSubModel(24);
@@ -152,7 +152,7 @@ public class RexsSubModelTest {
 	}
 
 	@Test
-	public void compareTo_comparesById() throws Exception {
+	public void compareTo_comparesById() {
 		RexsSubModel rexsSubModel23 = new RexsSubModel(23);
 		RexsSubModel rexsSubModel24 = new RexsSubModel(24);
 

--- a/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
@@ -28,7 +28,7 @@ import info.rexs.schema.constants.standard.RexsStandardVersions;
 public class RexsSchemaFileTest {
 
 	@Test
-	public void create_givenNullVersionThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullVersionThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				RexsSchemaFile.create(null);
@@ -72,14 +72,14 @@ public class RexsSchemaFileTest {
 	}
 
 	@Test
-	public void findByVersion_returnsRequestedRexsSchemaFile() throws Exception {
+	public void findByVersion_returnsRequestedRexsSchemaFile() {
 		RexsSchemaFile rexsSchemaFile = RexsSchemaFile.findByVersion(RexsStandardVersions.V1_2);
 		assertThat(rexsSchemaFile).isNotNull();
 		assertThat(rexsSchemaFile.getVersion()).isEqualTo(RexsStandardVersions.V1_2);
 	}
 
 	@Test
-	public void findByVersion_returnsNewlyCreatedRexsSchemaFile() throws Exception {
+	public void findByVersion_returnsNewlyCreatedRexsSchemaFile() {
 		RexsVersion newVersion = RexsVersion.create("66.7", null, "66.7");
 		RexsSchemaFile.create(newVersion);
 		RexsSchemaFile newRexsSchemaFile = RexsSchemaFile.findByVersion(newVersion);

--- a/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaFileTest.java
@@ -30,9 +30,7 @@ public class RexsSchemaFileTest {
 	@Test
 	public void create_givenNullVersionThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsSchemaFile.create(null);
-			})
+			.isThrownBy(() -> RexsSchemaFile.create(null))
 			.withMessage("version cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
@@ -57,9 +57,7 @@ public class RexsSchemaResolverTest {
 		});
 
 		assertThatIllegalStateException()
-			.isThrownBy(() -> {
-				RexsSchemaResolver.getInstance().resolve(newVersion);
-			})
+			.isThrownBy(() -> RexsSchemaResolver.getInstance().resolve(newVersion))
 			.withMessageStartingWith("could not load rexs schema for version");
 	}
 

--- a/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
+++ b/api/src/test/java/info/rexs/schema/RexsSchemaResolverTest.java
@@ -15,6 +15,16 @@
  */
 package info.rexs.schema;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
 import info.rexs.schema.constants.RexsAttributeId;
 import info.rexs.schema.constants.RexsComponentType;
 import info.rexs.schema.constants.RexsUnitId;
@@ -25,20 +35,11 @@ import info.rexs.schema.jaxb.Component;
 import info.rexs.schema.jaxb.RexsSchema;
 import info.rexs.schema.jaxb.Unit;
 import info.rexs.schema.jaxb.ValueType;
-import org.junit.Test;
-
-import java.io.InputStream;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 public class RexsSchemaResolverTest {
 
 	@Test
-	public void resolve_unknownRexsSchemaFileReturnsNull() throws Exception {
+	public void resolve_unknownRexsSchemaFileReturnsNull() {
 		RexsVersion newVersion = RexsVersion.create("67.6", null, "67.6");
 		assertThat(RexsSchemaResolver.getInstance().resolve(newVersion)).isNull();
 
@@ -63,7 +64,7 @@ public class RexsSchemaResolverTest {
 	}
 
 	@Test
-	public void resolve_cachingReturnsSameObjectForMultipleCalls() throws Exception {
+	public void resolve_cachingReturnsSameObjectForMultipleCalls() {
 		RexsSchema rexsSchema1 = RexsSchemaResolver.getInstance().resolve(RexsStandardVersions.getLatest());
 		RexsSchema rexsSchema2 = RexsSchemaResolver.getInstance().resolve(RexsStandardVersions.getLatest());
 
@@ -71,7 +72,7 @@ public class RexsSchemaResolverTest {
 	}
 
 	@Test
-	public void resolve_everyRexsStandardVersionHasRexsSchema() throws Exception {
+	public void resolve_everyRexsStandardVersionHasRexsSchema() {
 		List<RexsVersion> rexsStandardVersions = Stream.of(RexsStandardVersions.V1_0, RexsStandardVersions.V1_1, RexsStandardVersions.V1_2).collect(Collectors.toList());
 		for (RexsVersion version : rexsStandardVersions) {
 			RexsSchema rexsSchema = RexsSchemaResolver.getInstance().resolve(version);

--- a/api/src/test/java/info/rexs/schema/constants/RexsAttributeIdTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsAttributeIdTest.java
@@ -27,7 +27,7 @@ import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 public class RexsAttributeIdTest {
 
 	@Test
-	public void create_givenNullIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullIdThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				RexsAttributeId.create(null, RexsStandardUnitIds.kg);
@@ -36,7 +36,7 @@ public class RexsAttributeIdTest {
 	}
 
 	@Test
-	public void create_givenNullUnitThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullUnitThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 		.isThrownBy(() -> {
 			RexsAttributeId.create("foo_bar", null);
@@ -45,7 +45,7 @@ public class RexsAttributeIdTest {
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> {
 				RexsAttributeId.create("", RexsStandardUnitIds.kg);
@@ -54,7 +54,7 @@ public class RexsAttributeIdTest {
 	}
 
 	@Test
-	public void create_newAttributeIdHasIdAndUnit() throws Exception {
+	public void create_newAttributeIdHasIdAndUnit() {
 		RexsAttributeId newAttributeId = RexsAttributeId.create("foo", RexsStandardUnitIds.kg);
 		assertThat(newAttributeId.getId()).isEqualTo("foo");
 		assertThat(newAttributeId.getUnit()).isEqualTo(RexsStandardUnitIds.kg);
@@ -71,14 +71,14 @@ public class RexsAttributeIdTest {
 	}
 
 	@Test
-	public void findById_returnsRexsStandardAttributeId() throws Exception {
+	public void findById_returnsRexsStandardAttributeId() {
 		RexsAttributeId attributeId = RexsAttributeId.findById(RexsStandardAttributeIds.width.getId());
 		assertThat(attributeId).isNotNull();
 		assertThat(attributeId.getId()).isEqualTo(RexsStandardAttributeIds.width.getId());
 	}
 
 	@Test
-	public void findById_returnsNewlyCreatedAttributeId() throws Exception {
+	public void findById_returnsNewlyCreatedAttributeId() {
 		RexsAttributeId.create("bar", RexsStandardUnitIds.kg);
 		RexsAttributeId newAttributeId = RexsAttributeId.findById("bar");
 		assertThat(newAttributeId).isNotNull();

--- a/api/src/test/java/info/rexs/schema/constants/RexsAttributeIdTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsAttributeIdTest.java
@@ -29,27 +29,21 @@ public class RexsAttributeIdTest {
 	@Test
 	public void create_givenNullIdThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsAttributeId.create(null, RexsStandardUnitIds.kg);
-			})
+			.isThrownBy(() -> RexsAttributeId.create(null, RexsStandardUnitIds.kg))
 			.withMessage("id cannot be empty");
 	}
 
 	@Test
 	public void create_givenNullUnitThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-		.isThrownBy(() -> {
-			RexsAttributeId.create("foo_bar", null);
-		})
+		.isThrownBy(() -> RexsAttributeId.create("foo_bar", null))
 		.withMessage("unit cannot be empty");
 	}
 
 	@Test
 	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsAttributeId.create("", RexsStandardUnitIds.kg);
-			})
+			.isThrownBy(() -> RexsAttributeId.create("", RexsStandardUnitIds.kg))
 			.withMessage("id cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/schema/constants/RexsComponentTypeTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsComponentTypeTest.java
@@ -26,7 +26,7 @@ import info.rexs.schema.constants.standard.RexsStandardComponentTypes;
 public class RexsComponentTypeTest {
 
 	@Test
-	public void create_givenNullThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				RexsComponentType.create(null);
@@ -35,7 +35,7 @@ public class RexsComponentTypeTest {
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> {
 				RexsComponentType.create("");
@@ -44,7 +44,7 @@ public class RexsComponentTypeTest {
 	}
 
 	@Test
-	public void create_newComponentTypeHasId() throws Exception {
+	public void create_newComponentTypeHasId() {
 		RexsComponentType newComponentType = RexsComponentType.create("foo");
 		assertThat(newComponentType.getId()).isEqualTo("foo");
 	}
@@ -60,14 +60,14 @@ public class RexsComponentTypeTest {
 	}
 
 	@Test
-	public void findById_returnsRexsStandardComponentType() throws Exception {
+	public void findById_returnsRexsStandardComponentType() {
 		RexsComponentType componentType = RexsComponentType.findById(RexsStandardComponentTypes.coupling.getId());
 		assertThat(componentType).isNotNull();
 		assertThat(componentType.getId()).isEqualTo(RexsStandardComponentTypes.coupling.getId());
 	}
 
 	@Test
-	public void findById_returnsNewlyCreatedComponentType() throws Exception {
+	public void findById_returnsNewlyCreatedComponentType() {
 		RexsComponentType.create("bar");
 		RexsComponentType newComponentType = RexsComponentType.findById("bar");
 		assertThat(newComponentType).isNotNull();

--- a/api/src/test/java/info/rexs/schema/constants/RexsComponentTypeTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsComponentTypeTest.java
@@ -28,18 +28,14 @@ public class RexsComponentTypeTest {
 	@Test
 	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsComponentType.create(null);
-			})
+			.isThrownBy(() -> RexsComponentType.create(null))
 			.withMessage("id cannot be empty");
 	}
 
 	@Test
 	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsComponentType.create("");
-			})
+			.isThrownBy(() -> RexsComponentType.create(""))
 			.withMessage("id cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/schema/constants/RexsRelationRoleTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsRelationRoleTest.java
@@ -28,18 +28,14 @@ public class RexsRelationRoleTest {
 	@Test
 	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsRelationRole.create(null);
-			})
+			.isThrownBy(() -> RexsRelationRole.create(null))
 			.withMessage("key cannot be empty");
 	}
 
 	@Test
 	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsRelationRole.create("");
-			})
+			.isThrownBy(() -> RexsRelationRole.create(""))
 			.withMessage("key cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/schema/constants/RexsRelationRoleTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsRelationRoleTest.java
@@ -26,7 +26,7 @@ import info.rexs.schema.constants.standard.RexsStandardRelationRoles;
 public class RexsRelationRoleTest {
 
 	@Test
-	public void create_givenNullThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				RexsRelationRole.create(null);
@@ -35,7 +35,7 @@ public class RexsRelationRoleTest {
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> {
 				RexsRelationRole.create("");
@@ -44,7 +44,7 @@ public class RexsRelationRoleTest {
 	}
 
 	@Test
-	public void create_newRelationRoleHasKey() throws Exception {
+	public void create_newRelationRoleHasKey() {
 		RexsRelationRole newRelationRole = RexsRelationRole.create("foo");
 		assertThat(newRelationRole.getKey()).isEqualTo("foo");
 	}
@@ -60,14 +60,14 @@ public class RexsRelationRoleTest {
 	}
 
 	@Test
-	public void findByKey_returnsRexsStandardRelationRole() throws Exception {
+	public void findByKey_returnsRexsStandardRelationRole() {
 		RexsRelationRole relationRole = RexsRelationRole.findByKey(RexsStandardRelationRoles.inner_part.getKey());
 		assertThat(relationRole).isNotNull();
 		assertThat(relationRole.getKey()).isEqualTo(RexsStandardRelationRoles.inner_part.getKey());
 	}
 
 	@Test
-	public void findByKey_returnsNewlyCreatedRelationRole() throws Exception {
+	public void findByKey_returnsNewlyCreatedRelationRole() {
 		RexsRelationRole.create("bar");
 		RexsRelationRole newRelationRole = RexsRelationRole.findByKey("bar");
 		assertThat(newRelationRole).isNotNull();

--- a/api/src/test/java/info/rexs/schema/constants/RexsRelationTypeTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsRelationTypeTest.java
@@ -26,7 +26,7 @@ import info.rexs.schema.constants.standard.RexsStandardRelationTypes;
 public class RexsRelationTypeTest {
 
 	@Test
-	public void create_givenNullThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				RexsRelationType.create(null);
@@ -35,7 +35,7 @@ public class RexsRelationTypeTest {
 	}
 
 	@Test
-	public void create_givenEmptyIdThrowsIllegalArgumentException() throws Exception {
+	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> {
 				RexsRelationType.create("");
@@ -44,7 +44,7 @@ public class RexsRelationTypeTest {
 	}
 
 	@Test
-	public void create_newRelationTypeHasKey() throws Exception {
+	public void create_newRelationTypeHasKey() {
 		RexsRelationType newRelationType = RexsRelationType.create("foo");
 		assertThat(newRelationType.getKey()).isEqualTo("foo");
 	}
@@ -60,14 +60,14 @@ public class RexsRelationTypeTest {
 	}
 
 	@Test
-	public void findByKey_returnsRexsStandardRelationType() throws Exception {
+	public void findByKey_returnsRexsStandardRelationType() {
 		RexsRelationType relationType = RexsRelationType.findByKey(RexsStandardRelationTypes.central_shaft.getKey());
 		assertThat(relationType).isNotNull();
 		assertThat(relationType.getKey()).isEqualTo(RexsStandardRelationTypes.central_shaft.getKey());
 	}
 
 	@Test
-	public void findByKey_returnsNewlyCreatedRelationType() throws Exception {
+	public void findByKey_returnsNewlyCreatedRelationType() {
 		RexsRelationType.create("bar");
 		RexsRelationType newRelationType = RexsRelationType.findByKey("bar");
 		assertThat(newRelationType).isNotNull();

--- a/api/src/test/java/info/rexs/schema/constants/RexsRelationTypeTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsRelationTypeTest.java
@@ -28,18 +28,14 @@ public class RexsRelationTypeTest {
 	@Test
 	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsRelationType.create(null);
-			})
+			.isThrownBy(() -> RexsRelationType.create(null))
 			.withMessage("key cannot be empty");
 	}
 
 	@Test
 	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsRelationType.create("");
-			})
+			.isThrownBy(() -> RexsRelationType.create(""))
 			.withMessage("key cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/schema/constants/RexsUnitIdTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsUnitIdTest.java
@@ -19,41 +19,34 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 import org.junit.Test;
+
+import info.rexs.schema.constants.standard.RexsStandardUnitIds;
 
 public class RexsUnitIdTest {
 
 	@Test
 	public void create_givenNullThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				RexsUnitId.create(null);
-			})
+			.isThrownBy(() -> RexsUnitId.create(null))
 			.withMessage("id cannot be empty");
 	}
 
 	@Test
 	public void create_givenEmptyIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> {
-				RexsUnitId.create("");
-			})
+			.isThrownBy(() -> RexsUnitId.create(""))
 			.withMessage("id cannot be empty");
 
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> {
-					RexsUnitId.create("", 123);
-				})
+				.isThrownBy(() -> RexsUnitId.create("", 123))
 				.withMessage("id cannot be empty");
 	}
 
 	@Test
 	public void create_givenNegativeNumericIdThrowsIllegalArgumentException() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> {
-					RexsUnitId.create("unit", -1);
-				})
+				.isThrownBy(() -> RexsUnitId.create("unit", -1))
 				.withMessage("numericId cannot be negative");
 	}
 
@@ -64,9 +57,7 @@ public class RexsUnitIdTest {
 
 		// Attempt to create another unit with the same numeric ID (should throw an exception)
 		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> {
-					RexsUnitId.create("unit2", 123);
-				})
+				.isThrownBy(() -> RexsUnitId.create("unit2", 123))
 				.withMessage("numericId already exists");
 	}
 

--- a/api/src/test/java/info/rexs/upgrade/RexsUpgradeExceptionTest.java
+++ b/api/src/test/java/info/rexs/upgrade/RexsUpgradeExceptionTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class RexsUpgradeExceptionTest {
 
 	@Test
-	public void messageConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void messageConstructor_getterMatchesValuePassedToConstructor() {
 		String message = UUID.randomUUID().toString();
 		RexsUpgradeException ex = new RexsUpgradeException(message);
 
@@ -32,7 +32,7 @@ public class RexsUpgradeExceptionTest {
 	}
 
 	@Test
-	public void messageAndCauseConstructor_getterMatchesValuePassedToConstructor() throws Exception {
+	public void messageAndCauseConstructor_getterMatchesValuePassedToConstructor() {
 		Exception cause = new Exception("foo");
 		RexsUpgradeException ex = new RexsUpgradeException("bar", cause);
 

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
@@ -30,15 +30,11 @@ public class ChangelogFileTest {
 	@Test
 	public void create_givenNullVersionThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				ChangelogFile.create(null, RexsStandardVersions.V1_1);
-			})
+			.isThrownBy(() -> ChangelogFile.create(null, RexsStandardVersions.V1_1))
 			.withMessage("from version cannot be empty");
 
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> {
-				ChangelogFile.create(RexsStandardVersions.V1_0, null);
-			})
+			.isThrownBy(() -> ChangelogFile.create(RexsStandardVersions.V1_0, null))
 			.withMessage("to version cannot be empty");
 	}
 

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogFileTest.java
@@ -28,7 +28,7 @@ import info.rexs.schema.constants.standard.RexsStandardVersions;
 public class ChangelogFileTest {
 
 	@Test
-	public void create_givenNullVersionThrowsIllegalArgumentException() throws Exception {
+	public void create_givenNullVersionThrowsIllegalArgumentException() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> {
 				ChangelogFile.create(null, RexsStandardVersions.V1_1);

--- a/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
+++ b/api/src/test/java/info/rexs/upgrade/upgraders/changelog/ChangelogResolverTest.java
@@ -46,9 +46,7 @@ public class ChangelogResolverTest {
 		});
 
 		assertThatExceptionOfType(RexsUpgradeException.class)
-			.isThrownBy(() -> {
-				ChangelogResolver.getInstance().resolve(newChangelogFile);
-			})
+			.isThrownBy(() -> ChangelogResolver.getInstance().resolve(newChangelogFile))
 			.withMessageStartingWith("could not load rexs changelog for version");
 	}
 


### PR DESCRIPTION
I ran a few autofixes over the code and tested them briefly. No detailed analysis on all changes:

- Remove unnecessary 'throws' declarations
- Use uppercase "L" for long
- Remove redundant casts
- Replace statement lambda with expression lambda
- Removed unncessesary explicit type parameters
- Removed redundant modifiers
- Replaced lambda with method reference
- Simplify comparisons
- Use pattern variable where possible
- Replace overly complex comparisons by Objects.equals()

