### PR TITLE
Fixes + Add getAll() to RexsVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-- ?
+- Addded `RexsVerion.getAll()`.
 
 
 ## [0.12.0] - 2024-12-13

--- a/api/src/main/java/info/rexs/schema/constants/RexsVersion.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsVersion.java
@@ -144,6 +144,11 @@ public class RexsVersion {
 			schemaProvider = null;
 		}
 
+		// check for DEV
+		if (schemaVersion.equalsIgnoreCase(DEV_VERSION_NAME) && schemaProvider == null) {
+			return DEV;
+		}
+
 		// check for registered versions (both with and without schema provider)
 		for (RexsVersion version : allModelVersions.values()) {
 			if (schemaProvider == null) {

--- a/api/src/main/java/info/rexs/schema/constants/RexsVersion.java
+++ b/api/src/main/java/info/rexs/schema/constants/RexsVersion.java
@@ -1,6 +1,8 @@
 package info.rexs.schema.constants;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -13,18 +15,15 @@ import info.rexs.schema.constants.standard.RexsStandardVersions;
  */
 public class RexsVersion {
 
-	private static final String DEV_VERSION_NAME = "DEV";
-
-	/**
-	 * A constant representing the development version.
-	 */
-	public static final RexsVersion DEV = new RexsVersion(DEV_VERSION_NAME, null, DEV_VERSION_NAME);
-
 	/**
 	 * A constant representing an unknown version.
 	 */
 	public static final RexsVersion UNKNOWN = new RexsVersion("UNKNOWN", null, "UNKNOWN");
-
+	private static final String DEV_VERSION_NAME = "DEV";
+	/**
+	 * A constant representing the development version.
+	 */
+	public static final RexsVersion DEV = new RexsVersion(DEV_VERSION_NAME, null, DEV_VERSION_NAME);
 	/**
 	 * A map to store all versions by their model identifier.
 	 */
@@ -160,6 +159,20 @@ public class RexsVersion {
 
 		// return unknown if nothing matches
 		return UNKNOWN;
+	}
+
+	/**
+	 * Gets all registered REXS versions.
+	 *
+	 * @return A list of all registered REXS versions.
+	 */
+	public static List<RexsVersion> getAll() {
+		// create a list of all registered versions + DEV
+		List<RexsVersion> listOfVersions = new ArrayList<>(allModelVersions.values());
+		listOfVersions.add(DEV);
+
+		// return the list without duplicates
+		return listOfVersions.stream().distinct().toList();
 	}
 
 	/**

--- a/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
@@ -114,6 +114,16 @@ public class RexsVersionTest {
 	}
 
 	@Test
+	public void findBySchema_whenSchemaVersionIsDev_thenReturnDev() {
+		assertEquals(RexsVersion.DEV, RexsVersion.findBySchema("DEV", null));
+	}
+
+	@Test
+	public void findBySchema_whenSchemaVersionIsDevAndProviderIsNotExisting_thenReturnUnknown() {
+		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema("DEV", "non_existing_provider"));
+	}
+
+	@Test
 	public void findBySchema_whenSchemaVersionIsNull_thenReturnsUnknown() {
 		assertEquals(RexsVersion.UNKNOWN, RexsVersion.findBySchema(null, "provider"));
 	}

--- a/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
+++ b/api/src/test/java/info/rexs/schema/constants/RexsVersionTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+
 import org.junit.Test;
 
 import info.rexs.schema.constants.standard.RexsStandardVersions;
@@ -323,4 +325,26 @@ public class RexsVersionTest {
 		RexsVersion version = RexsVersion.create("1.0", "provider", "1.0");
 		assertEquals("1.0 (provider)", version.toString());
 	}
+
+	@Test
+	public void getAll_whenCalled_returnsAllRegisteredVersionsWithoutDuplicates() {
+		// Get all registered versions
+		List<RexsVersion> allVersions = RexsVersion.getAll();
+
+		// Verify that the list is not null
+		assertNotNull(allVersions);
+
+		// Verify that all entries to the list are unique
+		assertEquals(allVersions.size(), allVersions.stream().distinct().count());
+
+		// Verify that the registered versions are in the list
+		assertTrue(allVersions.stream().anyMatch(v -> v.equals(RexsStandardVersions.V1_0)));
+		assertTrue(allVersions.stream().anyMatch(v -> v.equals(RexsStandardVersions.V1_1)));
+		assertTrue(allVersions.stream().anyMatch(v -> v.equals(RexsStandardVersions.V1_7)));
+
+		// Verify that DEV is in that list but UNKNOWN isn't
+		assertTrue(allVersions.stream().anyMatch(v -> v.equals(RexsVersion.DEV)));
+		assertFalse(allVersions.stream().anyMatch(v -> v.equals(RexsVersion.UNKNOWN)));
+	}
+
 }


### PR DESCRIPTION
Changes to `RexsVersion`:
- Fix to `findBySchema`
- Adding the static method `getAll()`, which returns a list of all registered versions without duplicates

Code is test-covered.